### PR TITLE
Execution will continue even if date attribute not present.

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -119,14 +119,14 @@ def get_output_dir(date, outputdir):
     if outputdir.endswith(os.path.sep):
         outputdir = outputdir[:-1]
 
-    if date:
+    try:
         path = [
             outputdir,
             '%04d' % date['date'].year,
             '%02d' % date['date'].month,
             '%02d' % date['date'].day,
         ]
-    else:
+    except:
         path = [
             outputdir,
             'unknown',
@@ -141,7 +141,7 @@ def get_output_dir(date, outputdir):
 
 
 def get_file_name(file, date):
-    if date:
+    try:
         filename = [
             '%04d' % date['date'].year,
             '%02d' % date['date'].month,
@@ -157,7 +157,7 @@ def get_file_name(file, date):
 
         return ''.join(filename) + os.path.splitext(file)[1]
 
-    else:
+    except:
         return os.path.basename(file)
 
 


### PR DESCRIPTION
Program aborts execution with an exception if the date attribute is missing:

Traceback (most recent call last):
  File "phockup.py", line 263, in <module>
    main(sys.argv[1:])
  File "phockup.py", line 37, in main
    handle_file(os.path.join(root, filename), outputdir)
  File "phockup.py", line 181, in handle_file
    output_dir = get_output_dir(date, outputdir)
  File "phockup.py", line 125, in get_output_dir
    '%04d' % date['date'].year,
AttributeError: 'NoneType' object has no attribute 'year'
