### PR TITLE
Fix readme instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,9 +19,9 @@ sudo snap install phockup
 If you are using distro which doesn't support [snapd](https://snapcraft.io/docs/core/install) or you don't want to download the snap you can use the following commands to download the sorce and set it up
 ```
 sudo apt-get install libimage-exiftool-perl -y
-curl -L https://github.com/ivandokov/phockup/archive/v1.2.2.tar.gz -o phockup.tar.gz
+curl -L https://github.com/ivandokov/phockup/archive/1.2.2.tar.gz -o phockup.tar.gz
 tar -zxf phockup.tar.gz
-mv phockup-1.2.2 /opt
+sudo mv phockup-1.2.2 /opt
 sudo ln -s /opt/phockup-1.2.2/phockup.py /usr/local/bin/phockup
 ```
     


### PR DESCRIPTION
/opt ususally requires root permission
release filename missing letter v