### PR TITLE
Move option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /output
 phockup*.snap
 .python-version
+*.exe


### PR DESCRIPTION
Naive move implementation, decided against cleaning up possible empty directories after move because it's potentially destructive - `rm -rf` left as exercise for the user.

Closes #15 