### PR TITLE
Remove unneeded import

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -3,7 +3,6 @@ import getopt
 import hashlib
 import os
 import shutil
-import subprocess
 import sys
 import re
 from datetime import datetime


### PR DESCRIPTION
Remove "subprocess" import because it is not necessary.