### PR TITLE
v1.5.5: add option for using filestamp

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -10,7 +10,7 @@ from src.help import help
 from src.phockup import Phockup
 from src.printer import Printer
 
-version = '1.5.4'
+version = '1.5.5'
 printer = Printer()
 
 
@@ -21,9 +21,10 @@ def main(argv):
     link = False
     date_regex = None
     dir_format = os.path.sep.join(['%Y', '%m', '%d'])
+    timestamp = False
 
     try:
-        opts, args = getopt.getopt(argv[2:], "d:r:mlh", ["date=", "regex=", "move", "link", "help"])
+        opts, args = getopt.getopt(argv[2:], "d:r:mlth", ["date=", "regex=", "move", "link", "timestamp", "help"])
     except getopt.GetoptError:
         help(version)
         sys.exit(2)
@@ -52,6 +53,11 @@ def main(argv):
             except:
                 printer.error("Provided regex is invalid!")
                 sys.exit(2)
+        
+        if opt in ("-t", "--timestamp"):
+            timestamp = True
+            printer.line("Using file's timestamp!")
+        
 
     if link and move:
         printer.error("Can't use move and link strategy together!")
@@ -66,7 +72,8 @@ def main(argv):
         dir_format=dir_format,
         move=move,
         link=link,
-        date_regex=date_regex
+        date_regex=date_regex,
+        timestamp=timestamp
     )
 
 

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,8 @@ If any of the photos does not have date information you can use the `-r | --rege
 --regex="(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})"
 ```
 
+As a last resort, specify the `-t` option to use the file modification timestamp. This may not be accurate in all cases but can provide some kind of date if you'd rather it not go into the `unknown` folder. 
+
 ### Move files
 Instead of copying the process will move all files from the INPUTDIR to the OUTPUTDIR by using the flag `-m | --move`. This is useful when working with a big collection of files and the remaining free space is not enough to make a copy of the INPUTDIR.
 
@@ -112,6 +114,9 @@ pytest
 ```
 
 ## Changelog
+##### `1.5.5` 
+* Add `-t` option to allow using file modification time as a last resort
+* Workaround EXIF DateTaken time of all-zeros
 ##### `1.5.4`
 * Handle gracefully files without MIMEType
 ##### `1.5.3`

--- a/src/date.py
+++ b/src/date.py
@@ -26,7 +26,7 @@ class Date():
         return datetime(date_object["year"], date_object["month"], date_object["day"],
                         date_object["hour"], date_object["minute"], date_object["second"])
 
-    def from_exif(self, exif, timestamp, user_regex=None):
+    def from_exif(self, exif, timestamp=False, user_regex=None):
         keys = ['SubSecCreateDate', 'SubSecDateTimeOriginal', 'CreateDate', 'DateTimeOriginal']
 
         datestr = None
@@ -46,15 +46,14 @@ class Date():
         else:
             parsed_date = {'date': None, 'subseconds': ''}
 
-        try:
-            if parsed_date['date'] is not None:
-                return parsed_date
-            else:
-                raise TypeError("EXIF data couldn't be parsed into a date")
-        except TypeError:
+        if parsed_date.get("date") is not None:
+            return parsed_date
+        else:
             if timestamp: return self.from_timestamp()
-            return self.from_filename(user_regex)
-            
+            if self.file:
+                return self.from_filename(user_regex)
+            else:
+                return parsed_date
 
     def from_datestring(self, datestr):
         datestr = datestr.split('.')
@@ -100,6 +99,7 @@ class Date():
                     'date': date,
                     'subseconds': ''
                 }
+            
 
     def from_timestamp(self):
         date = datetime.fromtimestamp(os.path.getmtime(self.file))

--- a/src/date.py
+++ b/src/date.py
@@ -26,7 +26,7 @@ class Date():
         return datetime(date_object["year"], date_object["month"], date_object["day"],
                         date_object["hour"], date_object["minute"], date_object["second"])
 
-    def from_exif(self, exif, timestamp=False, user_regex=None):
+    def from_exif(self, exif, timestamp=None, user_regex=None):
         keys = ['SubSecCreateDate', 'SubSecDateTimeOriginal', 'CreateDate', 'DateTimeOriginal']
 
         datestr = None
@@ -36,7 +36,6 @@ class Date():
             if key in exif:
                 datestr = exif[key]
                 break
-        
         
         if isinstance(datestr,str): #sometimes this returns an int
             # sometimes exif data can return all zeros
@@ -49,9 +48,8 @@ class Date():
         if parsed_date.get("date") is not None:
             return parsed_date
         else:
-            if timestamp: return self.from_timestamp()
             if self.file:
-                return self.from_filename(user_regex)
+                return self.from_filename(user_regex, timestamp)
             else:
                 return parsed_date
 
@@ -77,7 +75,7 @@ class Date():
             'subseconds': subseconds
         }
 
-    def from_filename(self, user_regex):
+    def from_filename(self, user_regex, timestamp=None):
         # If missing datetime from EXIF data check if filename is in datetime format.
         # For this use a user provided regex if possible.
         # Otherwise assume a filename such as IMG_20160915_123456.jpg as default.
@@ -100,6 +98,7 @@ class Date():
                     'subseconds': ''
                 }
             
+        if timestamp: return self.from_timestamp()    
 
     def from_timestamp(self):
         date = datetime.fromtimestamp(os.path.getmtime(self.file))

--- a/src/help.py
+++ b/src/help.py
@@ -57,5 +57,8 @@ OPTIONS
         Example:
             {regex}
             can be used to extract the date from file names like the following IMG_27.01.2015-19.20.00.jpg.
+
+    -t | --timestamp
+        Use the timestamp of the file (last modified date) if there is no EXIF date information.
 """.format(version=version,
            regex="(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})"))

--- a/src/help.py
+++ b/src/help.py
@@ -59,6 +59,9 @@ OPTIONS
             can be used to extract the date from file names like the following IMG_27.01.2015-19.20.00.jpg.
 
     -t | --timestamp
-        Use the timestamp of the file (last modified date) if there is no EXIF date information.
+        Use the timestamp of the file (last modified date) if there is no EXIF date information. 
+        If the user supplies a regex, it will be used if it finds a match in the filename.
+        This option is intended as "last resort" since the file modified date may not be accurate, 
+        nevertheless it can be useful if no other date information can be obtained.
 """.format(version=version,
            regex="(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})"))

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -29,6 +29,7 @@ class Phockup():
         self.move = args.get('move', False)
         self.link = args.get('link', False)
         self.date_regex = args.get('date_regex', None)
+        self.timestamp = args.get('timestamp', False)
 
         self.check_directories()
         self.walk_directory()
@@ -89,6 +90,7 @@ class Phockup():
         """
         Generate output directory path based on the extracted date and formatted using dir_format
         If date is missing from the exifdata the file is going to "unknown" directory
+        unless user included a regex from filename or uses timestamp
         """
         try:
             path = [self.output, date['date'].date().strftime(self.dir_format)]
@@ -174,7 +176,7 @@ class Phockup():
         """
         exif_data = Exif(file).data()
         if exif_data and 'MIMEType' in exif_data and self.is_image_or_video(exif_data['MIMEType']):
-            date = Date(file).from_exif(exif_data, self.date_regex)
+            date = Date(file).from_exif(exif_data, self.timestamp, self.date_regex)
             output = self.get_output_dir(date)
             target_file_name = self.get_file_name(file, date).lower()
             target_file_path = os.path.sep.join([output, target_file_name])

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -144,7 +144,7 @@ class Phockup():
         while True:
             if os.path.isfile(target_file):
                 if self.checksum(file) == self.checksum(target_file):
-                    printer.line(' => skipped, duplicated file')
+                    printer.line(' => skipped, duplicated file %s' % target_file)
                     break
             else:
                 if self.move:

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -84,7 +84,7 @@ def test_get_date_custom_regex():
     A valid regex with a matching filename. Returns a datetime.
     """
     date_regex = re.compile("(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})")
-    assert Date("IMG_27.01.2015-19.20.00.jpg").from_exif({}, date_regex) == {
+    assert Date("IMG_27.01.2015-19.20.00.jpg").from_exif({}, False, date_regex) == {
         "date": datetime(2015, 1, 27, 19, 20, 00),
         "subseconds": ""
     }
@@ -96,7 +96,7 @@ def test_get_date_custom_regex_invalid():
     Return none because there is not enougth information in the filename.
     """
     date_regex = re.compile("(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})")
-    assert Date("19.20.00.jpg").from_exif({}, date_regex) is None
+    assert Date("19.20.00.jpg").from_exif({}, False, date_regex) is None
 
 
 def test_get_date_custom_regex_no_match():
@@ -104,4 +104,4 @@ def test_get_date_custom_regex_no_match():
     A valid regex with a non-matching filename.
     """
     date_regex = re.compile("(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})")
-    assert Date("Foo.jpg").from_exif({}, date_regex) is None
+    assert Date("Foo.jpg").from_exif({}, False, date_regex) is None

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -93,7 +93,7 @@ def test_get_date_custom_regex():
 def test_get_date_custom_regex_invalid():
     """
     A valid regex with a matching filename.
-    Return none because there is not enougth information in the filename.
+    Return none because there is not enough information in the filename.
     """
     date_regex = re.compile("(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})")
     assert Date("19.20.00.jpg").from_exif({}, False, date_regex) is None


### PR DESCRIPTION
hi! thanks for this useful project. i used it to cleanup a whole lot of old photos i had.  many of them didn't have EXIF data or had the wrong data, but the file timestamps (despite being very old) were in most cases good enough for my needs so I added an option to use the file timestamp if EXIF data isn't there (or can't be used).  I wanted to make it optional since I know there are definitely times when you wouldn't want to use this, especially when those timestamps may not be correct (which is why EXIF data is used first), but I think this could be useful for others too. 