### PR TITLE
Fix error handling when "--data=" is empty

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -37,7 +37,7 @@ def main(argv):
 
         if opt in ("-d", "--date"):
             if not arg:
-                printer.print.error("Date format cannot be empty")
+                printer.error("Date format cannot be empty")
             dir_format = Date().parse(arg)
 
         if opt in ("-m", "--move"):


### PR DESCRIPTION
This code was triggering an error when using "--data=" (with no value) as an argument, at least on Linux.
```
./phockup.py ~/tmp/thread2 ~/tmp/thread --date=
Traceback (most recent call last):
  File "./phockup.py", line 88, in <module>
    main(sys.argv[1:])
  File "./phockup.py", line 40, in main
    printer.print.error("Date format cannot be empty")
AttributeError: 'Printer' object has no attribute 'print'
```