### PR TITLE
Fix a unit test for case-sensitive filesystems

### DIFF
--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -175,7 +175,7 @@ def test_process_image_unknown(mocker):
         "MIMEType": "image/jpeg"
     }
     Phockup('input', 'output').process_file("input/UNKNOWN.jpg")
-    assert os.path.isfile("output/unknown/UNKNOWN.jpg")
+    assert os.path.isfile("output/unknown/unknown.jpg")
     shutil.rmtree('output', ignore_errors=True)
 
 


### PR DESCRIPTION
The test_process_image_unknown unit test triggers an error on case sensitive platforms, like Linux:
```
=============================================================================== FAILURES ================================================================================
______________________________________________________________________ test_process_image_unknown _______________________________________________________________________

mocker = <pytest_mock.MockFixture object at 0x7fe3b0a3c668>

    def test_process_image_unknown(mocker):
        shutil.rmtree('output', ignore_errors=True)
        mocker.patch.object(Phockup, 'check_directories')
        mocker.patch.object(Phockup, 'walk_directory')
        exif = {"input/UNKNOWN.jpg": {
            "MIMEType": "image/jpeg"
        }}
        Phockup('input', 'output').process_file(exif, "input/UNKNOWN.jpg")
>       assert os.path.isfile("output/unknown/UNKNOWN.jpg")
E       AssertionError: assert False
E        +  where False = <function isfile at 0x7fe3b4a059d8>('output/unknown/UNKNOWN.jpg')
E        +    where <function isfile at 0x7fe3b4a059d8> = <module 'posixpath' from '/usr/lib/python3.6/posixpath.py'>.isfile
E        +      where <module 'posixpath' from '/usr/lib/python3.6/posixpath.py'> = os.path

test_phockup.py:176: AssertionError
------------------------------------------------------------------------- Captured stdout call --------------------------------------------------------------------------
input/UNKNOWN.jpg => output/unknown/unknown.jpg
================================================================== 1 failed, 32 passed in 2.04 seconds ==================================================================
```

Python documentation says that the [os.path module](https://docs.python.org/2/library/os.path.html) respects the case convention of the host system. So the old code pass on Windows and Mac, but does not on Linux.