### PR TITLE
Add multithreading support

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -26,7 +26,7 @@ def main(argv):
     threads = 1
 
     try:
-        opts, args = getopt.getopt(argv[2:], "d:r:mltoh", ["date=", "regex=", "move", "link", "original-names", "timestamp", "threads=", "help"])
+        opts, args = getopt.getopt(argv[2:], "d:r:mltoxh", ["date=", "regex=", "move", "link", "original-names", "timestamp", "threads=", "help"])
     except getopt.GetoptError:
         help(version)
         sys.exit(2)

--- a/phockup.py
+++ b/phockup.py
@@ -23,9 +23,10 @@ def main(argv):
     dir_format = os.path.sep.join(['%Y', '%m', '%d'])
     original_filenames = False
     timestamp = False
+    threads = 1
 
     try:
-        opts, args = getopt.getopt(argv[2:], "d:r:mltoh", ["date=", "regex=", "move", "link", "original-names", "timestamp", "help"])
+        opts, args = getopt.getopt(argv[2:], "d:r:mltoh", ["date=", "regex=", "move", "link", "original-names", "timestamp", "threads=", "help"])
     except getopt.GetoptError:
         help(version)
         sys.exit(2)
@@ -62,6 +63,11 @@ def main(argv):
             timestamp = True
             printer.line("Using file's timestamp")
         
+        if opt in ("-x", "--threads"):
+            if not arg:
+                printer.error("Number of threads cannot be empty")
+            threads = int(arg)
+            printer.line("Using %s threads at most" % arg)
 
     if link and move:
         printer.error("Can't use move and link strategy together")
@@ -77,7 +83,8 @@ def main(argv):
         link=link,
         date_regex=date_regex,
         original_filenames=original_filenames,
-        timestamp=timestamp
+        timestamp=timestamp,
+        threads=threads
     )
 
 

--- a/readme.md
+++ b/readme.md
@@ -101,6 +101,9 @@ Instead of copying the process will create hard link all files from the INPUTDIR
 ### Original filenames
 Organize the files in selected format or using the default year/month/day format but keep original filenames by using the flag `-o | --original-names`.
 
+### Speed up with multithreading
+Set the argument `-x | --threads=` to speed up the processing time. Reasonable numbers go from `2` to `8` threads. You should set the number of threads based on the number of cores on your processor. Note that using threads increases cpu and disk usage and may impact the performance of other processes. 
+
 ## Development
 
 ### Running tests

--- a/src/help.py
+++ b/src/help.py
@@ -67,6 +67,6 @@ OPTIONS
         nevertheless it can be useful if no other date information can be obtained.
 
     -x <n> | --threads=<n>
-        Specify the number of threads to be used. Defaults to n=1 (multithreading disabled), with min 1 and max 16.
+        Specify the number of threads to be used. Defaults to n=1 (multithreading disabled), with min 1.
 """.format(version=version,
            regex="(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})"))

--- a/src/help.py
+++ b/src/help.py
@@ -65,5 +65,8 @@ OPTIONS
         If the user supplies a regex, it will be used if it finds a match in the filename.
         This option is intended as "last resort" since the file modified date may not be accurate, 
         nevertheless it can be useful if no other date information can be obtained.
+
+    -x <n> | --threads=<n>
+        Specify the number of threads to be used. Defaults to n=1 (multithreading disabled), with min 1 and max 16.
 """.format(version=version,
            regex="(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})"))

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -41,7 +41,7 @@ class Phockup():
             self.action = os.link
         else:
             self.action = shutil.copy2
-            
+
         self.check_directories()
         self.walk_directory()
 
@@ -183,30 +183,34 @@ class Phockup():
 
         targets = self.targets
         action = False
-        
+
         while True:
+            if os.path.isfile(target_file):
+                targets[target_file] = target_file
+
             target_source = targets.get(target_file)
             if target_source:
                 if self.checksum(file) == self.checksum(target_source):
                     printer.line('%s => skipped, duplicated file %s' % (file, target_file))
                     break
+
             else:
                 targets[target_file] = file
                 action = True
                 break
-                
+
             suffix += 1
             target_split = os.path.splitext(target_file_path)
             target_file = "%s-%d%s" % (target_split[0], suffix, target_split[1])
-            
+
         lock.release()
-        
+
         if action:
             try:
+                printer.line('%s => %s' % (file, target_file))
                 os.makedirs(output, exist_ok=True)
                 self.action(file, target_file)
                 self.process_xmp(file, target_file_name, suffix, output)
-                printer.line('%s => %s' % (file, target_file))
             except FileNotFoundError:
                 printer.line('%s => skipped, no such file or directory' % file)
 
@@ -251,5 +255,5 @@ class Phockup():
 
         if xmp_original:
             xmp_path = os.path.sep.join([output, xmp_target])
-            self.action(xmp_original, xmp_path)
             printer.line('%s => %s' % (xmp_original, xmp_path))
+            self.action(xmp_original, xmp_path)

--- a/src/printer.py
+++ b/src/printer.py
@@ -6,7 +6,7 @@ class Printer(object):
         if skip_end:
             print(message, end="", flush=True)
         else:
-            print(message)
+            print(message, flush=True)
 
     def error(self, message):
         self.line('')

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -242,6 +242,18 @@ def test_process_exists_same(mocker, capsys):
     shutil.rmtree('output', ignore_errors=True)
 
 
+def test_process_exists_same_prior(mocker, capsys):
+    shutil.rmtree('output', ignore_errors=True)
+    mocker.patch.object(Phockup, 'check_directories')
+    mocker.patch.object(Phockup, 'walk_directory')
+    os.makedirs("output/2017/01/01")
+    shutil.copy2("input/exif.jpg", "output/2017/01/01/20170101-010101.jpg")
+    phockup = Phockup('input', 'output')
+    phockup.process_file("input/exif.jpg")
+    assert 'skipped, duplicated file' in capsys.readouterr()[0]
+    shutil.rmtree('output', ignore_errors=True)
+
+
 def test_process_same_date_different_files_rename(mocker):
     shutil.rmtree('output', ignore_errors=True)
     mocker.patch.object(Phockup, 'check_directories')


### PR DESCRIPTION
### How it works
I chose the simpler way I could find to add multithreading support. The idea is to parallelize the `process_file` function, so multiple files could be processed at once. To achieve this, the `files` list is split into subsets and each subset goes into the function `process_file_worker`, where the multithreading takes place.

The new `-x | --threads=<n>` option is used to set the number of threads. When `<n>` is 1, the behaviour is the same as previously. When `<n>` is bigger than 1, the number of threads is set to the minimum value between `<n>` and the number of files to be processed. 

### Results
Processing a folder with 36 real jpg files takes about **7s** with the current version:
> ~> time phockup input output --move 
6.43user 0.52system **0:06.77elapsed** 102%CPU (0avgtext+0avgdata 17544maxresident)k

While the multithreaded version took about **3s**:
> ~> time phockup input output --move --threads 4
9.28user 0.69system **0:03.23elapsed** 309%CPU (0avgtext+0avgdata 17596maxresident)k

The gain in speed is often higher than **2x**.

### Notes
Because a list of all files needs to be created before the processing starts, it may take longer to walk though big file trees and start showing some progress. A test with 1000 empty files still shows a speed gain of **2.3x**, with the current version taking 3min31s, and the multithreading version 1min31s using 8 threads. Memory usage was almost the same for both: 6MB vs 6.4MB. An advantage of knowing all the files prior processing is that it would be possible to show the _progress status_ or even an _ETA_, but I haven't digged into it.     

Another issue is that it's not possible to guarantee the order of files being output as finished. The file list is split in a way that helps keeping the original order in the output, but as soon as the threads desynchronize, the order gets a bit messy. I also didn't find an easy way to keep the `print` command flushing properly and even with a thread lock and python3's `flush=True`, I was still getting a messed output. The solution was to use a unique print statement to output each each file processed to _stdout_.

The code passed the 42 unit tests. I'm not sure if new unit tests are needed though.

This is my first time playing with multithreading, so the code probably isn't in its best shape yet. :-]

Adds: #46 