### PR TITLE
Fix regex support for incomplete time on filename

### DIFF
--- a/src/date.py
+++ b/src/date.py
@@ -24,7 +24,9 @@ class Date():
 
     def build(self, date_object):
         return datetime(date_object["year"], date_object["month"], date_object["day"],
-                        date_object["hour"], date_object["minute"], date_object["second"])
+                        date_object["hour"] if date_object.get("hour") else 0,
+                        date_object["minute"] if date_object.get("minute") else 0,
+                        date_object["second"] if date_object.get("second") else 0)
 
     def from_exif(self, exif, timestamp=None, user_regex=None):
         keys = ['SubSecCreateDate', 'SubSecDateTimeOriginal', 'CreateDate', 'DateTimeOriginal']


### PR DESCRIPTION
I took a look on issue #39 and it seems to be part of a bug, part user fault. 

The bug was in the `build` function of `Date` objects, that could not handle missing hour/minute/second information from the filename, like the filename in the referenced issue "**img-20161026-wa0011.jpg**", at least on Linux.

The user fault was to write `-r=`  with a "=" in the command. Valid syntaxes are `-r <value>`,  `--regex=<value>` or  `--regex <value>`. Using Anything after the -r" is taken as part of <value> and then the regex would starts with an "=" and fail. 

After correcting the command, the date would have being extracted, but the bug in build function would avoid it to be correctly used.

### Note
I could have fixed the issue right in the `from_filename` function (where regex is used)  instead of the `build` function, but I believe supporting a `datetime` object creation when hour info is missing is a more elegant solution. 

Since the application is not dependent on hour to create the output dirs, it serves more like a suffix to the filename, which is automatically generated in case of collisions. Missing hour information still allows it to get a valid output and should be supported widely.