### PR TITLE
Handle regex with optional hour information

### DIFF
--- a/src/date.py
+++ b/src/date.py
@@ -87,7 +87,7 @@ class Date():
 
         if matches:
             try:
-                match_dir = matches.groupdict()
+                match_dir = matches.groupdict(default='0')
                 match_dir = dict([a, int(x)] for a, x in match_dir.items())  # Convert str to int
                 date = self.build(match_dir)
             except (KeyError, ValueError):

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -105,3 +105,14 @@ def test_get_date_custom_regex_no_match():
     """
     date_regex = re.compile(r"(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})")
     assert Date("Foo.jpg").from_exif({}, False, date_regex) is None
+
+def test_get_date_custom_regex_optional_time():
+    """
+    A valid regex with a matching filename that doesn't have hour information.
+    However, the regex in question has hour information as optional.
+    """
+    date_regex = re.compile(r"(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?((?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2}))?")
+    assert Date("IMG_27.01.2015.jpg").from_exif({}, False, date_regex) == {
+        "date": datetime(2015, 1, 27, 0, 0, 00),
+        "subseconds": ""
+    }


### PR DESCRIPTION
Fixes #61 

When doing `groupdict` to get the regex information from a filename as a dictionary, the default value of a match is set to 0 so the program won't crash.