### PR TITLE
Dry run option

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -24,9 +24,10 @@ def main(argv):
     original_filenames = False
     timestamp = False
     date_field = None
+    dry_run = False
 
     try:
-        opts, args = getopt.getopt(argv[2:], "d:r:f:mltoh", ["date=", "regex=", "move", "link", "original-names", "timestamp", "date-field=", "help"])
+        opts, args = getopt.getopt(argv[2:], "d:r:f:mltoyh", ["date=", "regex=", "move", "link", "original-names", "timestamp", "date-field=", "dry-run", "help"])
     except getopt.GetoptError:
         help(version)
         sys.exit(2)
@@ -58,11 +59,15 @@ def main(argv):
                 date_regex = re.compile(arg)
             except:
                 printer.error("Provided regex is invalid")
-        
+
         if opt in ("-t", "--timestamp"):
             timestamp = True
             printer.line("Using file's timestamp")
-        
+
+        if opt in ("-y", "--dry-run"):
+            dry_run = True
+            printer.line("Dry run only, not moving files only showing changes")
+
         if opt in ("-f", "--date-field"):
             if not arg:
                 printer.error("Date field cannot be empty")
@@ -85,7 +90,8 @@ def main(argv):
         date_regex=date_regex,
         original_filenames=original_filenames,
         timestamp=timestamp,
-        date_field=date_field
+        date_field=date_field,
+        dry_run=dry_run,
     )
 
 

--- a/src/help.py
+++ b/src/help.py
@@ -80,5 +80,8 @@ OPTIONS
 
         To get all date fields available for a file, do:
             exiftool -time:all -mimetype -j <file>
+
+    -y | --dry-run
+        Don't move any files, just show which changes would be done.
 """.format(version=version,
            regex="(?P<day>\d{2})\.(?P<month>\d{2})\.(?P<year>\d{4})[_-]?(?P<hour>\d{2})\.(?P<minute>\d{2})\.(?P<second>\d{2})"))

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -32,6 +32,7 @@ class Phockup():
         self.date_regex = args.get('date_regex', None)
         self.timestamp = args.get('timestamp', False)
         self.date_field = args.get('date_field', False)
+        self.dry_run = args.get('dry_run', False)
 
         self.check_directories()
         self.walk_directory()
@@ -48,7 +49,8 @@ class Phockup():
         if not os.path.exists(self.output):
             printer.line('Output directory "%s" does not exist, creating now' % self.output)
             try:
-                os.makedirs(self.output)
+                if not self.dry_run:
+                    os.makedirs(self.output)
             except Exception:
                 printer.error('Cannot create output directory. No write access!')
 
@@ -99,7 +101,7 @@ class Phockup():
 
         fullpath = os.path.sep.join(path)
 
-        if not os.path.isdir(fullpath):
+        if not os.path.isdir(fullpath) and not self.dry_run:
             os.makedirs(fullpath)
 
         return fullpath
@@ -153,15 +155,17 @@ class Phockup():
             else:
                 if self.move:
                     try:
-                        shutil.move(file, target_file)
+                        if not self.dry_run:
+                            shutil.move(file, target_file)
                     except FileNotFoundError:
                         printer.line(' => skipped, no such file or directory')
                         break
-                elif self.link:
+                elif self.link and not self.dry_run:
                     os.link(file, target_file)
                 else:
                     try:
-                        shutil.copy2(file, target_file)
+                        if not self.dry_run:
+                            shutil.copy2(file, target_file)
                     except FileNotFoundError:
                         printer.line(' => skipped, no such file or directory')
                         break
@@ -216,9 +220,10 @@ class Phockup():
             xmp_path = os.path.sep.join([output, xmp_target])
             printer.line('%s => %s' % (xmp_original, xmp_path))
 
-            if self.move:
-                shutil.move(xmp_original, xmp_path)
-            elif self.link:
-                os.link(xmp_original, xmp_path)
-            else:
-                shutil.copy2(xmp_original, xmp_path)
+            if not self.dry_run:
+                if self.move:
+                    shutil.move(xmp_original, xmp_path)
+                elif self.link:
+                    os.link(xmp_original, xmp_path)
+                else:
+                    shutil.copy2(xmp_original, xmp_path)

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -73,6 +73,18 @@ def test_walking_directory():
     shutil.rmtree('output', ignore_errors=True)
 
 
+def test_dry_run():
+    shutil.rmtree('output', ignore_errors=True)
+    Phockup('input', 'output', dry_run=True)
+    assert not os.path.isdir('output')
+    dir1='output/2017/01/01'
+    dir2='output/2017/10/06'
+    dir3='output/unknown'
+    assert not os.path.isdir(dir1)
+    assert not os.path.isdir(dir2)
+    assert not os.path.isdir(dir3)
+
+
 def test_is_image_or_video(mocker):
     mocker.patch.object(Phockup, 'check_directories')
     assert Phockup('in', '.').is_image_or_video("image/jpeg")


### PR DESCRIPTION
Proposal for #67 : `-y` or `--dry-run` cause the same output as a normal run, but don't move, copy or link any files.