### PR TITLE
Fix for #70 1.5.8 not working in Windows

### DIFF
--- a/src/exif.py
+++ b/src/exif.py
@@ -1,6 +1,7 @@
 from subprocess import check_output, CalledProcessError
 import json
 import shlex
+import sys
 
 
 class Exif(object):
@@ -9,9 +10,12 @@ class Exif(object):
 
     def data(self):
         try:
-            data = check_output('exiftool -time:all -mimetype -j %s' % shlex.quote(self.file), shell=True).decode('UTF-8')
+            exif_command = 'exiftool -time:all -mimetype -j %s' % shlex.quote(self.file)
+            if sys.platform == 'win32':
+                exif_command = exif_command.replace("\'", "\"")
+            data = check_output(exif_command, shell=True).decode('UTF-8')
             exif = json.loads(data)[0]
-        except (CalledProcessError, UnicodeDecodeError):
+        except (CalledProcessError, UnicodeDecodeError) as e:
             return None
 
         return exif

--- a/src/exif.py
+++ b/src/exif.py
@@ -15,7 +15,7 @@ class Exif(object):
                 exif_command = exif_command.replace("\'", "\"")
             data = check_output(exif_command, shell=True).decode('UTF-8')
             exif = json.loads(data)[0]
-        except (CalledProcessError, UnicodeDecodeError) as e:
+        except (CalledProcessError, UnicodeDecodeError):
             return None
 
         return exif


### PR DESCRIPTION
Fixes #70, the issue appears to have been that Windows CMD needs the file argument to exiftool be double quoted, single quoting doesn't work. 