### PR TITLE
Bug/exif date tz

### DIFF
--- a/src/date.py
+++ b/src/date.py
@@ -74,6 +74,8 @@ class Date():
                 parsed_date_time = self.strptime(date, "%Y-%m-%d %H:%M:%S")
             except ValueError:
                 parsed_date_time = None
+        if re.search(search, subseconds) is not None:
+            subseconds = re.sub(search, r'\1', subseconds)
         return {
             'date': parsed_date_time,
             'subseconds': subseconds

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -41,6 +41,15 @@ def test_get_date_from_exif_strip_timezone():
     }
 
 
+def test_get_date_from_exif_strip_timezone_sub_sec():
+    assert Date().from_exif({
+        "SubSecCreateDate": "2019:10:06 11:02:50.575+01:00"
+    }) == {
+        "date": datetime(2019, 10, 6, 11, 2, 50),
+        "subseconds": "575"
+    }
+
+
 def test_get_date_from_exif_colon():
     assert Date().from_exif({
         "CreateDate": "2017:01:01 01:01:01"


### PR DESCRIPTION
Some of my photos taken on an iPhone 6s Plus include subseconds and a timezone value. This has caused zero byte files to be created in the output location on Windows. On Linux the files are created ok but include the timezone value as part of the filename.

This PR removes the timezone value from the subsecond variable. By doing this the filename no longer includes a timezone value in this situation and is written successfully on Windows.