### PR TITLE
Copy2 chmod error - Prefix and Suffix options

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -111,6 +111,22 @@ nevertheless it can be useful if no other date information can be obtained.
     )
 
     parser.add_argument(
+        "-p",
+        "--prefix",
+        action="store",
+        default='',
+        help="Prefix to be inserted before file name",
+    )
+
+    parser.add_argument(
+        "-s",
+        "--suffix",
+        action="store",
+        default='',
+        help="Suffix to be inserted after file name before the extension",
+    )
+
+    parser.add_argument(
         "-r",
         "--regex",
         action="store",
@@ -166,6 +182,8 @@ To get all date fields available for a file, do:
         original_filenames=args.original_names,
         timestamp=args.timestamp,
         date_field=args.date_field,
+        prefix=args.prefix,
+        suffix=args.suffix,
         dry_run=args.dry_run,
     )
 

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -113,11 +113,11 @@ class Phockup():
         Generate file name based on exif data unless it is missing or
         original filenames are required. Then use original file name
         """
-        local_path_filename, local_file_extension = os.path.splitext(original_filename)
-        local_filename = os.path.basename(local_path_filename)
+        path_filename, file_extension = os.path.splitext(original_filename)
+        filename = os.path.basename(path_filename)
 
         if self.original_filenames:
-            return (self.prefix + local_filename + self.suffix + local_file_extension)
+            return (self.prefix + filename + self.suffix + file_extension)
 
         try:
             filename = [
@@ -133,7 +133,7 @@ class Phockup():
             if date['subseconds']:
                 filename.append(date['subseconds'])
 
-            return self.prefix + ''.join(filename) + self.suffix + local_file_extension
+            return self.prefix + ''.join(filename) + self.suffix + file_extension
         except:
             return os.path.basename(original_filename)
 


### PR DESCRIPTION
HI

Theres a bug in copy2, that if a system doesn't support chmod it throws an OSError exeception. There been an issue open since 2016 for this, go see shutils. Anyhow when using phockup of a NFS mounted drive chmod is not available , so added catch for OSError.

Also added two options for adding text to the files name either as a prefix or a suffix or both. in the case of suffix the text in added before the extension. I need to keep the original file name but add some text so I could identify the copies.

Sorry, I should have done this on a branch but was did it as I was sorting out my photos.

Phil