### PR TITLE
Python 3's f-Strings updated to improved String Formatting Syntax.

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -11,7 +11,7 @@ from src.dependency import check_dependencies
 from src.phockup import Phockup
 
 
-__version__ = "1.6.0"
+__version__ = '1.6.0'
 
 PROGRAM_DESCRIPTION = """Media sorting tool to organize photos and videos \
 from your camera in folders by year, month and day.
@@ -23,7 +23,7 @@ the proper directory for year, month and day.
 
 DEFAULT_DIR_FORMAT = ['%Y', '%m', '%d']
 
-logger = logging.getLogger("phockup")
+logger = logging.getLogger('phockup')
 
 
 def parse_args(args=sys.argv[1:]):
@@ -31,18 +31,18 @@ def parse_args(args=sys.argv[1:]):
         description=PROGRAM_DESCRIPTION,
         formatter_class=argparse.RawTextHelpFormatter)
 
-    parser.version = "v{}".format(__version__)
+    parser.version = f"v{__version__}"
 
     parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
+        '-v',
+        '--version',
+        action='version',
     )
 
     parser.add_argument(
-        "-d",
-        "--date",
-        action="store",
+        '-d',
+        '--date',
+        action='store',
         type=Date().parse,
         help="""\
 Specify date format for OUTPUTDIR directories.
@@ -70,9 +70,9 @@ Example:
     exclusive_group_link_move = parser.add_mutually_exclusive_group()
 
     exclusive_group_link_move.add_argument(
-        "-m",
-        "--move",
-        action="store_true",
+        '-m',
+        '--move',
+        action='store_true',
         help="""\
 Instead of copying the process will move all files from the INPUTDIR to the \
 OUTPUTDIR.
@@ -82,9 +82,9 @@ remaining free space is not enough to make a copy of the INPUTDIR.
     )
 
     exclusive_group_link_move.add_argument(
-        "-l",
-        "--link",
-        action="store_true",
+        '-l',
+        '--link',
+        action='store_true',
         help="""\
 Instead of copying the process will make hard links to all files in INPUTDIR \
 and place them in the OUTPUTDIR.
@@ -94,9 +94,9 @@ YYYY/MM/DD structure to point to same files.
     )
 
     parser.add_argument(
-        "-o",
-        "--original-names",
-        action="store_true",
+        '-o',
+        '--original-names',
+        action='store_true',
         help="""\
 Organize the files in selected format or using the default year/month/day \
 format but keep original filenames.
@@ -104,9 +104,9 @@ format but keep original filenames.
     )
 
     parser.add_argument(
-        "-t",
-        "--timestamp",
-        action="store_true",
+        '-t',
+        '--timestamp',
+        action='store_true',
         help="""\
 Use the timestamp of the file (last modified date) if there is no EXIF date \
 information.
@@ -119,9 +119,9 @@ nevertheless it can be useful if no other date information can be obtained.
     )
 
     parser.add_argument(
-        "-y",
-        "--dry-run",
-        action="store_true",
+        '-y',
+        '--dry-run',
+        action='store_true',
         help="""\
 Does a trial run with no permanent changes to the filesystem.
 So it will not move any files, just shows which changes would be done.
@@ -129,20 +129,20 @@ So it will not move any files, just shows which changes would be done.
     )
 
     parser.add_argument(
-        "--maxdepth",
+        '--maxdepth',
         type=int,
         default=-1,
         choices=range(0, 255),
-        metavar="1-255",
+        metavar='1-255',
         help="""\
 Descend at most 'maxdepth' levels (a non-negative integer) of directories
 """,
     )
 
     parser.add_argument(
-        "-r",
-        "--regex",
-        action="store",
+        '-r',
+        '--regex',
+        action='store',
         type=re.compile,
         help="""\
 Specify date format for date extraction from filenames if there is no EXIF \
@@ -156,9 +156,9 @@ Example:
     )
 
     parser.add_argument(
-        "-f",
-        "--date-field",
-        action="store",
+        '-f',
+        '--date-field',
+        action='store',
         help="""\
 Use a custom date extracted from the exif field specified.
 To set multiple fields to try in order until finding a valid date,
@@ -179,8 +179,8 @@ To get all date fields available for a file, do:
     exclusive_group_debug_silent = parser.add_mutually_exclusive_group()
 
     exclusive_group_debug_silent.add_argument(
-        "--debug",
-        action="store_true",
+        '--debug',
+        action='store_true',
         default=False,
         help="""\
 Enable debugging.
@@ -188,8 +188,8 @@ Enable debugging.
     )
 
     exclusive_group_debug_silent.add_argument(
-        "--quiet",
-        action="store_true",
+        '--quiet',
+        action='store_true',
         default=False,
         help="""\
 Run without output.
@@ -197,8 +197,8 @@ Run without output.
     )
 
     parser.add_argument(
-        "--log-file",
-        action="store",
+        '--log-file',
+        action='store',
         help="""\
 Specify the output directory where your log file should be exported.
 This flag can be used in conjunction with the flag `-q | --quiet`.
@@ -206,16 +206,16 @@ This flag can be used in conjunction with the flag `-q | --quiet`.
     )
 
     parser.add_argument(
-        "input_dir",
-        metavar="INPUTDIR",
+        'input_dir',
+        metavar='INPUTDIR',
         help="""\
 Specify the source directory where your photos are located.
 """,
     )
 
     parser.add_argument(
-        "output_dir",
-        metavar="OUTPUTDIR",
+        'output_dir',
+        metavar='OUTPUTDIR',
         help="""\
 Specify the output directory where your photos should be exported.
 """,
@@ -226,10 +226,10 @@ Specify the output directory where your photos should be exported.
 
 def setup_logging(options):
     """Configure logging."""
-    root = logging.getLogger("")
+    root = logging.getLogger('')
     root.setLevel(logging.WARNING)
     formatter = logging.Formatter(
-        "[%(asctime)s] - [%(levelname)s] - %(message)s", "%Y-%m-%d %H:%M:%S")
+        '[%(asctime)s] - [%(levelname)s] - %(message)s', '%Y-%m-%d %H:%M:%S')
     ch = logging.StreamHandler()
     ch.setFormatter(formatter)
     root.addHandler(ch)

--- a/src/date.py
+++ b/src/date.py
@@ -8,15 +8,15 @@ class Date():
         self.filename = filename
 
     def parse(self, date):
-        date = date.replace("YYYY", "%Y")  # 2017 (year)
-        date = date.replace("YY", "%y")  # 17 (year)
-        date = date.replace("m", "%b")  # Dec (month)
-        date = date.replace("MM", "%m")  # 12 (month)
-        date = date.replace("M", "%B")  # December (month)
-        date = date.replace("DDD", "%j")  # 123 (day or year)
-        date = date.replace("DD", "%d")  # 25 (day)
-        date = date.replace("\\", os.path.sep)  # path separator
-        date = date.replace("/", os.path.sep)  # path separator
+        date = date.replace('YYYY', '%Y')  # 2017 (year)
+        date = date.replace('YY', '%y')  # 17 (year)
+        date = date.replace('m', '%b')  # Dec (month)
+        date = date.replace('MM', '%m')  # 12 (month)
+        date = date.replace('M', '%B')  # December (month)
+        date = date.replace('DDD', '%j')  # 123 (day or year)
+        date = date.replace('DD', '%d')  # 25 (day)
+        date = date.replace('\\', os.path.sep)  # path separator
+        date = date.replace('/', os.path.sep)  # path separator
         return date
 
     def strptime(self, date, date_format):
@@ -24,10 +24,10 @@ class Date():
 
     def build(self, date_object):
         return datetime(
-            date_object["year"], date_object["month"], date_object["day"],
-            date_object["hour"] if date_object.get("hour") else 0,
-            date_object["minute"] if date_object.get("minute") else 0,
-            date_object["second"] if date_object.get("second") else 0)
+            date_object['year'], date_object['month'], date_object['day'],
+            date_object['hour'] if date_object.get('hour') else 0,
+            date_object['minute'] if date_object.get('minute') else 0,
+            date_object['second'] if date_object.get('second') else 0)
 
     def from_exif(self, exif, timestamp=None, user_regex=None,
                   date_field=None):
@@ -53,7 +53,7 @@ class Date():
         else:
             parsed_date = {'date': None, 'subseconds': ''}
 
-        if parsed_date.get("date") is not None:
+        if parsed_date.get('date') is not None:
             return parsed_date
         else:
             if self.filename:
@@ -72,10 +72,10 @@ class Date():
         if re.search(search, date) is not None:
             date = re.sub(search, r'\1', date)
         try:
-            parsed_date_time = self.strptime(date, "%Y:%m:%d %H:%M:%S")
+            parsed_date_time = self.strptime(date, '%Y:%m:%d %H:%M:%S')
         except ValueError:
             try:
-                parsed_date_time = self.strptime(date, "%Y-%m-%d %H:%M:%S")
+                parsed_date_time = self.strptime(date, '%Y-%m-%d %H:%M:%S')
             except ValueError:
                 parsed_date_time = None
         if re.search(search, subseconds) is not None:

--- a/src/dependency.py
+++ b/src/dependency.py
@@ -1,7 +1,7 @@
 import shutil
 import logging
 
-logger = logging.getLogger("phockup")
+logger = logging.getLogger('phockup')
 
 
 def check_dependencies():

--- a/src/exif.py
+++ b/src/exif.py
@@ -11,11 +11,9 @@ class Exif(object):
     def data(self):
         try:
             if sys.platform == 'win32':
-                exif_command = 'exiftool -time:all -mimetype -j "{}"'\
-                    .format(self.filename)
+                exif_command = f'exiftool -time:all -mimetype -j "{self.filename}"'
             else:
-                exif_command = 'exiftool -time:all -mimetype -j {}'\
-                    .format(shlex.quote(self.filename))
+                exif_command = f'exiftool -time:all -mimetype -j {shlex.quote(self.filename)}'
             data = check_output(exif_command, shell=True).decode('UTF-8')
             exif = json.loads(data)[0]
         except (CalledProcessError, UnicodeDecodeError):

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -10,7 +10,7 @@ from src.date import Date
 from src.exif import Exif
 
 
-logger = logging.getLogger("phockup")
+logger = logging.getLogger('phockup')
 
 
 ignored_files = ('.DS_Store', 'Thumbs.db')
@@ -57,17 +57,16 @@ permanent changes)...")
 
         if not os.path.isdir(self.input_dir) or not \
                 os.path.exists(self.input_dir):
-            raise RuntimeError("Input directory '{}' does not exist or \
-cannot be accessed".format(self.input_dir))
+            raise RuntimeError(f"Input directory '{self.input_dir}' does not exist or \
+cannot be accessed")
         if not os.path.exists(self.output_dir):
-            logger.warning("Output directory {} does not exist, creating now"
-                           .format(self.output_dir))
+            logger.warning(f"Output directory '{self.output_dir}' does not exist, creating now")
             try:
                 if not self.dry_run:
                     os.makedirs(self.output_dir)
             except OSError:
-                raise OSError("Cannot create output '{}' directory. No write \
-access!".format(self.output_dir))
+                raise OSError(f"Cannot create output '{self.output_dir}' directory. No write \
+access!")
 
     def walk_directory(self):
         """
@@ -137,13 +136,13 @@ access!".format(self.output_dir))
 
         try:
             filename = [
-                '{:04d}'.format(date['date'].year),
-                '{:02d}'.format(date['date'].month),
-                '{:02d}'.format(date['date'].day),
+                f'{(date["date"].year):04d}',
+                f'{(date["date"].month):02d}',
+                f'{(date["date"].day):02d}',
                 '-',
-                '{:02d}'.format(date['date'].hour),
-                '{:02d}'.format(date['date'].minute),
-                '{:02d}'.format(date['date'].second),
+                f'{(date["date"].hour):02d}',
+                f'{(date["date"].minute):02d}',
+                f'{(date["date"].second):02d}',
             ]
 
             if date['subseconds']:
@@ -162,7 +161,7 @@ access!".format(self.output_dir))
         if str.endswith(filename, '.xmp'):
             return None
 
-        progress = "{}".format(filename)
+        progress = f'{filename}'
 
         output, target_file_name, target_file_path = \
             self.get_file_name_and_path(filename)
@@ -173,8 +172,7 @@ access!".format(self.output_dir))
         while True:
             if os.path.isfile(target_file):
                 if self.checksum(filename) == self.checksum(target_file):
-                    progress = "{} => skipped, duplicated file {}"\
-                            .format(progress, target_file)
+                    progress = f'{progress} => skipped, duplicated file {target_file}'
                     logger.info(progress)
                     break
             else:
@@ -183,8 +181,7 @@ access!".format(self.output_dir))
                         if not self.dry_run:
                             shutil.move(filename, target_file)
                     except FileNotFoundError:
-                        progress = "{} => skipped, no such file or directory"\
-                                .format(progress)
+                        progress = f'{progress} => skipped, no such file or directory'
                         logger.warning(progress)
                         break
                 elif self.link and not self.dry_run:
@@ -194,12 +191,11 @@ access!".format(self.output_dir))
                         if not self.dry_run:
                             shutil.copy2(filename, target_file)
                     except FileNotFoundError:
-                        progress = "{} => skipped, no such file or directory"\
-                                .format(progress)
+                        progress = f'{progress} => skipped, no such file or directory'
                         logger.warning(progress)
                         break
 
-                progress = "{} => {}".format(progress, target_file)
+                progress = f'{progress} => {target_file}'
                 logger.info(progress)
 
                 self.process_xmp(filename, target_file_name, suffix, output)
@@ -207,8 +203,7 @@ access!".format(self.output_dir))
 
             suffix += 1
             target_split = os.path.splitext(target_file_path)
-            target_file = "{}-{}{}"\
-                .format(target_split[0], suffix, target_split[1])
+            target_file = f'{target_split[0]}-{suffix}{target_split[1]}'
 
     def get_file_name_and_path(self, filename):
         """
@@ -239,21 +234,20 @@ access!".format(self.output_dir))
         xmp_original_without_ext = os.path.splitext(original_filename)[0] \
             + '.xmp'
 
-        suffix = "-{}".format(suffix) if suffix > 1 else ''
+        suffix = f'-{suffix}' if suffix > 1 else ''
 
         xmp_files = {}
 
         if os.path.isfile(xmp_original_with_ext):
-            xmp_target = "{}{}.xmp".format(file_name, suffix)
+            xmp_target = f'{file_name}{suffix}.xmp'
             xmp_files[xmp_original_with_ext] = xmp_target
         if os.path.isfile(xmp_original_without_ext):
-            xmp_target = "{}{}.xmp"\
-                .format(os.path.splitext(file_name)[0], suffix)
+            xmp_target = f'{(os.path.splitext(file_name)[0])}{suffix}.xmp'
             xmp_files[xmp_original_without_ext] = xmp_target
 
         for original, target in xmp_files.items():
             xmp_path = os.path.sep.join([output, target])
-            logger.info("{} => {}".format(original, xmp_path))
+            logger.info(f'{original} => {xmp_path}')
 
             if not self.dry_run:
                 if self.move:


### PR DESCRIPTION
As promised:

Python 3's f-Strings updated to improved String Formatting Syntax.

I have also tried to adhere to the following as much as possible:
_Use single-quotes for string literals, e.g. 'my-identifier', but use double-quotes for strings that are likely to contain single-quote characters as part of the string itself (such as error messages, or any strings containing natural language), e.g. "You've got an error!".

Single-quotes are easier to read and to type, but if a string contains single-quote characters then double-quotes are better than escaping the single-quote characters or wrapping the string in double single-quotes._