### PR TITLE
Add paragraph on duplicate handling in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ The software will collect all files from the input directory and copy them to th
 
 All files which are not images or videos or those which do not have creation date information will be placed in a directory called `unknown` without file name change. By doing this you can be sure that the input directory can be safely deleted after the successful process completion because **all** files from the input directory have a copy in the output directory.
 
+If the target file already exists, its checksum is compared with the source to determine if it is a duplicate. If the checksums are different, we do not have a duplicate and the target filename will be suffixed with a number, for example "-1". If the checksums match, the copy operation will be skipped. 
+
 ## Installation
 ### Linux (snap)
 Requires [snapd](https://snapcraft.io/docs/core/install)


### PR DESCRIPTION
Thanks for this tool :)

I saw "skipped, duplicated file X" in the output and it was unclear to me if this was simply based on filename or on file contents. I found something about this in the issue tracker (https://github.com/ivandokov/phockup/issues/112) and I thought it would be useful to add this to the README.