### PR TITLE
Initial implementation of Allowing Unknown Images directory naming

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -253,7 +253,7 @@ videos only, use `--file-type=[image|video]`.
         type=str,
         default=Phockup.DEFAULT_NO_DATE_DIRECTORY,
         help="""\
-Files without EXIF date information are placed in a directory 
+Files without EXIF date information are placed in a directory
 named 'unknown' by default.  This option overrides that
 folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
 """,

--- a/phockup.py
+++ b/phockup.py
@@ -20,7 +20,6 @@ directory without changing the files content. It will only rename the files and 
 them in the proper directory for year, month and day.
 """
 
-DEFAULT_DIR_FORMAT = ['%Y', '%m', '%d']
 
 logger = logging.getLogger('phockup')
 
@@ -249,6 +248,17 @@ videos only, use `--file-type=[image|video]`.
 """,
     )
 
+    parser.add_argument(
+        '--no-date-dir',
+        type=str,
+        default=Phockup.DEFAULT_NO_DATE_DIRECTORY,
+        help="""\
+Files without EXIF date information are placed in a directory 
+named 'unknown' by default.  This option overrides that
+folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
+""",
+    )
+
     return parser.parse_args(args)
 
 
@@ -292,7 +302,8 @@ def main(options):
         progress=options.progress,
         max_depth=options.maxdepth,
         file_type=options.file_type,
-        max_concurrency=options.max_concurrency
+        max_concurrency=options.max_concurrency,
+        no_date_dir=options.no_date_dir
     )
 
 

--- a/phockup.py
+++ b/phockup.py
@@ -127,7 +127,7 @@ So it will not move any files, just shows which changes would be done.
         '--max-concurrency',
         type=int,
         default=1,
-        choices=range(1,255),
+        choices=range(1, 255),
         metavar='1-255',
         help="Sets the level of concurrency for processing files in a "
              "directory.  Defaults to 1.  Higher values can improve "

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -20,6 +20,9 @@ ignored_files = ('.DS_Store', 'Thumbs.db')
 
 
 class Phockup():
+    DEFAULT_DIR_FORMAT = ['%Y', '%m', '%d']
+    DEFAULT_NO_DATE_DIRECTORY = "unknown"
+
     def __init__(self, input_dir, output_dir, **args):
         start_time = time.time()
         self.files_processed = 0
@@ -37,7 +40,8 @@ class Phockup():
 
         self.input_dir = input_dir
         self.output_dir = output_dir
-        self.dir_format = args.get('dir_format') or os.path.sep.join(['%Y', '%m', '%d'])
+        self.no_date_dir = args.get('no_date_dir') or Phockup.DEFAULT_NO_DATE_DIRECTORY
+        self.dir_format = args.get('dir_format') or os.path.sep.join(Phockup.DEFAULT_DIR_FORMAT)
         self.move = args.get('move', False)
         self.link = args.get('link', False)
         self.original_filenames = args.get('original_filenames', False)
@@ -184,7 +188,7 @@ class Phockup():
         try:
             path = [self.output_dir, date['date'].date().strftime(self.dir_format)]
         except (TypeError, ValueError):
-            path = [self.output_dir, 'unknown']
+            path = [self.output_dir, self.no_date_dir]
 
         fullpath = os.path.sep.join(path)
 

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -413,3 +413,25 @@ def validate_copy_operation():
                 os.path.isfile(os.path.join(dir3, name))]) == 1
     assert len([name for name in os.listdir(dir4) if
                 os.path.isfile(os.path.join(dir4, name))]) == 1
+
+
+def test_no_exif_directory():
+    shutil.rmtree('output', ignore_errors=True)
+    Phockup('input', 'output', no_date_dir='misc')
+    dir1 = 'output/2017/01/01'
+    dir2 = 'output/2017/10/06'
+    dir3 = 'output/misc'
+    dir4 = 'output/2018/01/01/'
+    assert os.path.isdir(dir1)
+    assert os.path.isdir(dir2)
+    assert os.path.isdir(dir3)
+    assert os.path.isdir(dir4)
+    assert len([name for name in os.listdir(dir1) if
+                os.path.isfile(os.path.join(dir1, name))]) == 3
+    assert len([name for name in os.listdir(dir2) if
+                os.path.isfile(os.path.join(dir2, name))]) == 1
+    assert len([name for name in os.listdir(dir3) if
+                os.path.isfile(os.path.join(dir3, name))]) == 1
+    assert len([name for name in os.listdir(dir4) if
+                os.path.isfile(os.path.join(dir4, name))]) == 1
+    shutil.rmtree('output', ignore_errors=True)


### PR DESCRIPTION
Initial implementation of https://github.com/ivandokov/phockup/issues/74 

Allows user to specify where Unknown date files go via a command line parameter.  Parameter `--no-date-dir` overrides the default of "unknown".  

### Usage:
`phockup INPUTDIR OUTPUTDIR --no-date-dir=UNKNOWNDIR`

### Example usage:

`phockup ~/Pictures/camera ~/Pictures/sorted --no-date-dir=Miscellaneous `

This would put all files without valid EXIF date information in the `~/Pictures/sorted/Miscellaneous` directory.

Also included: 
- Added pytest use case named `test_no_exif_directory` for alternative `unknown` directory name testing.
- Refactored phockup constants to the Phockup class ease of scoping for imports and tight coupling to the class. 
`DEFAULT_DIR_FORMAT = ['%Y', '%m', '%d']`
`DEFAULT_NO_DATE_DIRECTORY = "unknown"`
- Implemented the existing `DEFAULT_DIR_FORMAT` constant as the fallback case for the `--d\--date` command line parameter