### PR TITLE
Initial implementation of "this week in pictures"

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -57,12 +57,16 @@ Supported formats:
     m    - Jul, Aug, Sept ...
     DD   - 27, 28, 29 ... (day of month)
     DDD  - 123, 158, 365 ... (day of year)
+    U    - 00, 01, 53 ... (week of the year, Sunday first day of week)
+    W    - 00, 01, 53 ... (week of the year, Monday first day of week)
 
 Example:
     YYYY/MM/DD -> 2011/07/17
     YYYY/M/DD  -> 2011/July/17
     YYYY/m/DD  -> 2011/Jul/17
     YY/m-DD    -> 11/Jul-17
+    YYYY/U     -> 2011/30
+    YYYY/W     -> 2011/28
 """,
     )
 
@@ -128,7 +132,7 @@ So it will not move any files, just shows which changes would be done.
         '--max-concurrency',
         type=int,
         default=1,
-        choices=range(1,255),
+        choices=range(1, 255),
         metavar='1-255',
         help="Sets the level of concurrency for processing files in a "
              "directory.  Defaults to 1.  Higher values can improve "

--- a/readme.md
+++ b/readme.md
@@ -92,12 +92,16 @@ Supported formats:
     m    - Jul, Aug, Sept ...
     DD   - 27, 28, 29 ... (day of month)
     DDD  - 123, 158, 365 ... (day of year)
+    U    - 00, 01, 53 ... (week of the year, Sunday first day of week)
+    W    - 00, 01, 53 ... (week of the year, Monday first day of week)
 
 Example:
     YYYY/MM/DD -> 2011/07/17
     YYYY/M/DD  -> 2011/July/17
     YYYY/m/DD  -> 2011/Jul/17
     YY/m-DD    -> 11/Jul-17
+    YYYY/U     -> 2011/30
+    YYYY/W     -> 2011/28
 ```
 
 ### Missing date information in EXIF

--- a/src/date.py
+++ b/src/date.py
@@ -16,6 +16,8 @@ class Date:
         date = date.replace('M', '%B')  # December (month)
         date = date.replace('DDD', '%j')  # 123 (day or year)
         date = date.replace('DD', '%d')  # 25 (day)
+        date = date.replace('U', '%U')  # Week number (Sunday as the first day)
+        date = date.replace('W', '%W')  # Week number (Monday as the first day)
         date = date.replace('\\', os.path.sep)  # path separator
         date = date.replace('/', os.path.sep)  # path separator
         return date


### PR DESCRIPTION
Added support for parsing 'W' and 'U' as optional week of the year formats.

As requested in https://github.com/ivandokov/phockup/issues/85

Opted to only support it on the output format rather and not on the file name parsing RegEx.  Seemed awkward to parse "date" information that may only contain a week of the year if the output was a `YYYY/MM/DD` format.

Updated command line and readme documentation