### PR TITLE
Add Cronjob and Environment Variables to Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
 FROM python:3.9-alpine
 
+VOLUME /mnt/input
+VOLUME /mnt/output
+
+ENV CRON "* * * * *"
+ENV OPTIONS ""
+
 COPY . /opt/phockup
+RUN chmod +x /opt/phockup/entrypoint.sh
 
 RUN apk --no-cache add exiftool \
     && pip install --no-cache-dir --use-feature=2020-resolver -r /opt/phockup/requirements.txt \
-    && ln -s /opt/phockup/phockup.py /usr/local/bin/phockup
+    && ln -s /opt/phockup/phockup.py /usr/local/bin/phockup \
+    && apk add bash
 
-ENTRYPOINT [ "phockup" ]
+ENTRYPOINT ["/opt/phockup/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+CRON_COMMAND="$CRON phockup /mnt/input /mnt/output $OPTIONS"
+echo "$CRON_COMMAND" >> /etc/crontabs/root
+echo "cron job has been set up with command: $CRON_COMMAND"
+
+crond -f -d 8


### PR DESCRIPTION
This should solve issue/feature request  #144.

Input and output folders can be set through -v /host/input:/mnt/input -v /host/output:/mnt/output.

The Cron-String defaults to  * * * * * but can be set through -e "CRON=1 1 1 1 1"
Optional Parameters can be set through -e "OPTIONS=--move --original-names"