### PR TITLE
Skip checksum when reorganizing folder

### DIFF
--- a/src/phockup.py
+++ b/src/phockup.py
@@ -264,7 +264,7 @@ but looking for '{self.file_type}'"
                 break
 
             if os.path.isfile(target_file):
-                if self.checksum(filename) == self.checksum(target_file):
+                if filename != target_file and self.checksum(filename) == self.checksum(target_file):
                     progress = f'{progress} => skipped, duplicated file {target_file}'
                     self.duplicates_found += 1
                     if self.progress:


### PR DESCRIPTION
I found this tool useful for organizing a folder I previously used phockup in. In that case, both source and destination directories are the same. since the directories are the same, it tried to move every file into itself and check the checksums if they are equivalent. We can skip the checksum since we know it's the same file since they have the same paths. This would greatly speed up reorganizing a directory.