### PR TITLE
Address Issue #79 to skip "Unknown" files (based on EXIF data)

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -20,6 +20,7 @@ directory without changing the files content. It will only rename the files and 
 them in the proper directory for year, month and day.
 """
 
+DEFAULT_DIR_FORMAT = ['%Y', '%m', '%d']
 
 logger = logging.getLogger('phockup')
 
@@ -263,6 +264,16 @@ folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
 """,
     )
 
+    parser.add_argument(
+        '--skip-unknown',
+        action='store_true',
+        default=False,
+        help="""\
+    Ignore files that don't contain valid EXIF data for the criteria specified.
+    This is useful if you intend to make multiple passes over an input directory
+    with varying and specific EXIF fields that are note checked by default.
+    """, )
+
     return parser.parse_args(args)
 
 
@@ -307,7 +318,8 @@ def main(options):
         max_depth=options.maxdepth,
         file_type=options.file_type,
         max_concurrency=options.max_concurrency,
-        no_date_dir=options.no_date_dir
+        no_date_dir=options.no_date_dir,
+        skip_unknown=options.skip_unknown
     )
 
 

--- a/src/date.py
+++ b/src/date.py
@@ -44,7 +44,8 @@ class Date:
         datestr = None
 
         for key in keys:
-            if key in exif:
+            # Skip 'bad' dates that return integers (-1) or have the format 0000...
+            if key in exif and isinstance(exif[key], str) and not exif[key].startswith('0000'):
                 datestr = exif[key]
                 break
 

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -420,18 +420,31 @@ def test_no_exif_directory():
     Phockup('input', 'output', no_date_dir='misc')
     dir1 = 'output/2017/01/01'
     dir2 = 'output/2017/10/06'
+    dir3 = 'output/unknown'
+    dir4 = 'output/2018/01/01/'
+    assert os.path.isdir(dir1)
+    assert os.path.isdir(dir2)
+    assert not os.path.isdir(dir3)
+    assert os.path.isdir(dir4)
+    shutil.rmtree('output', ignore_errors=True)
+
+
+def test_skip_unknown():
+    shutil.rmtree('output', ignore_errors=True)
+    Phockup('input', 'output', skip_unknown=True)
+    dir1 = 'output/2017/01/01'
+    dir2 = 'output/2017/10/06'
     dir3 = 'output/misc'
     dir4 = 'output/2018/01/01/'
     assert os.path.isdir(dir1)
     assert os.path.isdir(dir2)
-    assert os.path.isdir(dir3)
+    # No files should exist in this directory becaues they were skipped
+    assert not os.path.isdir(dir3)
     assert os.path.isdir(dir4)
     assert len([name for name in os.listdir(dir1) if
                 os.path.isfile(os.path.join(dir1, name))]) == 3
     assert len([name for name in os.listdir(dir2) if
                 os.path.isfile(os.path.join(dir2, name))]) == 1
-    assert len([name for name in os.listdir(dir3) if
-                os.path.isfile(os.path.join(dir3, name))]) == 1
     assert len([name for name in os.listdir(dir4) if
                 os.path.isfile(os.path.join(dir4, name))]) == 1
     shutil.rmtree('output', ignore_errors=True)


### PR DESCRIPTION
Implemented --skip-unknown flag to leave files without matching EXIF data in place.
Added test_skip_unknown test to the harness

This has proved useful to me when the folder structure contains metadata that I can use to process images on the second or third pass with additional flags.  Having them moved to a single folder loses the taxonomy that the images may have, so having them stay in place is useful to me.

See Issue #79 for additional details.