### PR TITLE
Replace checksum method with native filecmp.cmp() method

### DIFF
--- a/src/phockup.py
+++ b/src/phockup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import concurrent.futures
-import hashlib
+import filecmp
 import logging
 import os
 import re
@@ -151,18 +151,6 @@ class Phockup():
                 del dirnames[:]
         return file_count
 
-    def checksum(self, filename):
-        """
-        Calculate checksum for a file.
-        Used to match if duplicated file name is actually a duplicated file.
-        """
-        block_size = 65536
-        sha256 = hashlib.sha256()
-        with open(filename, 'rb') as f:
-            for block in iter(lambda: f.read(block_size), b''):
-                sha256.update(block)
-        return sha256.hexdigest()
-
     def get_file_type(self, mimetype):
         """
         Check if given file_type is image or video
@@ -264,7 +252,7 @@ but looking for '{self.file_type}'"
                 break
 
             if os.path.isfile(target_file):
-                if self.checksum(filename) == self.checksum(target_file):
+                if filecmp.cmp(filename, target_file, shallow=False):
                     progress = f'{progress} => skipped, duplicated file {target_file}'
                     self.duplicates_found += 1
                     if self.progress:


### PR DESCRIPTION
Replacing `checksum()` method with native `filecmp.cmp()` method to leverage inherent caching of checksums for comparison (particularly with large duplicate data sets).  Defaulted to `shallow=False` due to paranoia.

See https://docs.python.org/3/library/filecmp.html

I came across this option when doing a lot of network copies with lots of duplicates.  This implementation seems to improve throughput on comparisons for a large number of duplicate files.  

Below is a simple test, but the speed improvement was enough to compel me to make this PR.  Note that due to network and computer issues, the `filecmp.cmp()` version took longer, but spent less time comparing files.  If I could create a local test case that had consistent numbers, I would.  But I figured the ~30% reduction in comparison time in my simple test warranted putting it out to the community for testing.  Plus, it's a native library that may perform better on different platforms/implementations.

**filecmp.cmp() Version**
```
[2022-06-20 20:23:26] - [INFO] - Total time spent comparing files: 4.8738062382
[2022-06-20 20:23:26] - [INFO] - Processed 7981 files in 13605.04 seconds. Average Throughput: 0.59 files/second
[2022-06-20 20:23:26] - [INFO] - Found 1125 duplicate files.
[2022-06-20 20:23:26] - [INFO] - Would have copied 6856 files.
```
**Checksum Version**
```
[2022-06-21 10:24:15] - [INFO] - Total time spent comparing files: 6.9732189178
[2022-06-21 10:24:15] - [INFO] - Processed 7981 files in 4235.57 seconds. Average Throughput: 1.88 files/second
[2022-06-21 10:24:15] - [INFO] - Found 1125 duplicate files.
[2022-06-21 10:24:15] - [INFO] - Would have copied 6856 files.
```
No feelings will be hurt if this PR isn't accepted.

