### PR TITLE
Allowed for duplicate target paths to exist for mkdirs 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ else
   if [ -f /tmp/phockup.lockfile ]; then
     rm /tmp/phockup.lockfile
   fi
-  
+
   CRON_COMMAND="$CRON flock -n /tmp/phockup.lockfile phockup /mnt/input /mnt/output $OPTIONS"
 
   echo "$CRON_COMMAND" >> /etc/crontabs/root
@@ -17,4 +17,3 @@ else
 
   crond -f -d 8
 fi
-

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -187,7 +187,7 @@ class Phockup():
         fullpath = os.path.sep.join(path)
 
         if not os.path.isdir(fullpath) and not self.dry_run:
-            os.makedirs(fullpath)
+            os.makedirs(fullpath, exist_ok=True)
 
         return fullpath
 


### PR DESCRIPTION
Allows for concurrent threads to attempt to create the same directory without throwing an exception if another thread creates it first.  Most frequently occurs when using multiple threads and network shares with phockup (now I tested).  This fix alleviates the collision created by the 'slow' folder creation across networks that was throwing exceptions.

Fix was to add `exists_ok=True` to the `os.mkdirs()` call on missing target directories.

See https://github.com/ivandokov/phockup/issues/149