### PR TITLE
Docker arm64 build

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,38 @@
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.14
+
+VOLUME /mnt/input
+VOLUME /mnt/output
+
+ENV CRON ""
+ENV OPTIONS ""
+ENV TZ="Etc/UTC"
+
+COPY . .
+RUN chmod +x entrypoint_aarch64.sh
+RUN chmod +x phockup.py
+
+RUN \
+  echo "**** install build packages ****" && \
+  apk add --no-cache --virtual=build-dependencies \
+    build-base && \
+  echo "**** install packages ****" && \
+  apk add --no-cache \
+    curl \
+    exiftool \
+    flock \
+    py3-pip \
+    python3 && \
+  pip3 install -U --no-cache-dir pip && \
+  pip install -U --no-cache-dir --find-links https://wheel-index.linuxserver.io/alpine/  -r \
+    requirements.txt && \
+  echo "**** clean up ****" && \
+  apk del --purge \
+    build-dependencies && \
+  rm -rf \
+    /root/.cache \
+    /root/.cargo \
+    /tmp/*
+
+USER $PUID:$PGID
+
+ENTRYPOINT ["./entrypoint_aarch64.sh"]

--- a/entrypoint_aarch64.sh
+++ b/entrypoint_aarch64.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+chown -R $PUID:$PGID /mnt/input
+chown -R $PUID:$PGID /mnt/output
+
+# If the CRON variable is empty, phockup gets executed once as command line tool
+if [ -z "$CRON" ]; then
+  /phockup.py $@
+
+# When CRON is not empty, phockup will run in a cron job until the container is stopped.
+else
+  if [ -f /tmp/phockup.lockfile ]; then
+    rm /tmp/phockup.lockfile
+  fi
+
+  CRON_COMMAND="$CRON flock -n /tmp/phockup.lockfile /phockup.py /mnt/input /mnt/output $OPTIONS"
+
+  crontab -l > mycron
+  echo "$CRON_COMMAND" >> mycron
+  crontab mycron
+  rm mycron
+
+  echo "cron job has been set up with command: $CRON_COMMAND"
+
+  crond -f -d 8
+fi


### PR DESCRIPTION
Cron working as well. Possible to specify the user and the timezone.

For example:

phockup:
  container_name: phockup
  image: tiagoqpinto/phockup:v1.9.0
  restart: always
  volumes:
    - INPUT_FOLDER:/mnt/input
    - OUTPUT_FOLDER:/mnt/output
  environment:
    - OPTIONS=-d YYYY -m
    - PUID=${PUID}
    - PGID=${PGID}
    - TZ=Europe/Lisbon
    - CRON=0 2 * * *
