### PR TITLE
Implementation of Issue #146 to support prefix and suffix

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -274,6 +274,29 @@ folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
     with varying and specific EXIF fields that are note checked by default.
     """, )
 
+    parser.add_argument(
+        '--output_prefix',
+        type=str,
+        default='',
+        help="""\
+        String to prepend to the output directory to aid in sorting
+        files by an additional level prior to sorting by date.  This
+        string will immediately follow the output path and is intended
+        to allow runtime setting of the output path (e.g. via $USER,
+        $HOSTNAME, %USERNAME%, etc.)
+        """
+    )
+
+    parser.add_argument(
+        '--output_suffix',
+        type=str,
+        default='',
+        help="""\
+        String to append to the destination directory to aid in sorting
+        files by an additional level after sorting by date.
+        """
+    )
+
     return parser.parse_args(args)
 
 
@@ -319,7 +342,9 @@ def main(options):
         file_type=options.file_type,
         max_concurrency=options.max_concurrency,
         no_date_dir=options.no_date_dir,
-        skip_unknown=options.skip_unknown
+        skip_unknown=options.skip_unknown,
+        output_prefix=options.output_prefix,
+        output_suffix=options.output_suffix
     )
 
 

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,94 @@ Example:
     YYYY/W     -> 2011/28
 ```
 
+### Prefix/Suffix
+In order to support both aggregation and finer granularity of files
+sorted, you can specify a prefix or suffix (or both) to aid in storing
+files in directories beyond strictly date.
+
+*NOTE:* Prefixes and suffixes will also apply to the **'unknown'** folder to
+isolate files that cannot be processed into their respective folders.
+This creates a bit more chaos for 'unknown' files, but should allow
+them to be managed by whomever they "belong" to.
+
+#### Prefix
+`--output-prefix` flag can be used to specify a directory to be
+appended to the `OUTPUTDIR`, and thus prepended to the date.
+
+For example:
+```
+phockup ~/Pictures/camera /mnt/sorted --output_prefix=nikon
+```
+would place files in folders similar to:
+```
+/mnt/sorted/nikon/2011/07/17
+/mnt/sorted/nikon/unknown
+```
+
+While it may seem to be redundant with `OUTPUTDIR`, this flag is
+intended to add support for more cleanly determining the output
+directory at run-time via environment variable expansion (i.e. use
+$USER, %USERNAME%, $HOSTNAME, etc. to aggregate files)
+
+For example:
+```
+phockup ~/Pictures/camera /mnt/sorted --output_prefix=$USER
+```
+
+would yield an output directory of
+```
+/mnt/sorted/ivandokov/2011/07/17
+/mnt/sorted/ivandokov/unknown
+```
+
+This allows the same script to be deployed to multiple users/machines
+and allows sorting into their respective top level directories.
+
+#### Suffix
+`--output-suffix` flag can be used to specify a directory within the
+target date directory for a file.  This allows files to be sorted in
+their respective date/time folders while additionally adding a
+directory based on the suffix value for additional metadata.
+
+For example:
+```
+phockup ~/Pictures/DCIM/NIKOND40 /mnt/sorted --output_suffix=nikon
+phockup ~/Pictures/DCIM/100APPLE /mnt/sorted --output_suffix=iphone
+```
+
+This would allow files to be stored in the following structure:
+
+```
+/mnt/sorted/2011/07/17/nikon/DCS_0001.NEF
+...
+/mnt/sorted/2011/07/17/nikon/DCS_0099.NEF
+/mnt/sorted/unknown/nikon/
+
+/mnt/sorted/2011/07/17/iphone/ABIL6163.HEIC
+...
+/mnt/sorted/2011/07/17/iphone/YZYE9497.HEIC
+/mnt/sorted/unknown/iphone/
+```
+
+The output suffix also allows for environment variable expansion (e.g.
+$USER, $HOSTNAME, %USERNAME%, etc.) allowing dynamic folders to
+represent additional metadata about the images.
+
+For example:
+
+```
+phockup ~/Pictures/ /mnt/sorted --output_suffix=$HOSTNAME
+
+or
+
+phockup ~/Pictures/ /mnt/sorted --output_suffix=$USER
+```
+could be used to sort images based on the source computer or user,
+perventing hetrogenous collections of images from disparate sources
+saving to the same central respository.
+
+The two options above can be used to help sort/store images
+
 ### Missing date information in EXIF
 If any of the photos does not have date information you can use the `-r | --regex` option to specify date format for date extraction from filenames:
 ```

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -73,7 +73,32 @@ def test_exception_for_no_write_access_when_creating_output_dir(mocker):
 def test_walking_directory():
     shutil.rmtree('output', ignore_errors=True)
     Phockup('input', 'output')
-    validate_copy_operation()
+    validate_copy_operations()
+    shutil.rmtree('output', ignore_errors=True)
+
+
+def test_walking_directory_prefix():
+    shutil.rmtree('output', ignore_errors=True)
+    prefix = "Phockup Images"
+    Phockup('input', 'output', output_prefix=prefix)
+    validate_copy_operations(prefix=prefix)
+    shutil.rmtree('output', ignore_errors=True)
+
+
+def test_walking_directory_suffix():
+    shutil.rmtree('output', ignore_errors=True)
+    suffix = "iphone"
+    Phockup('input', 'output', output_suffix=suffix)
+    validate_copy_operations(suffix=suffix)
+    shutil.rmtree('output', ignore_errors=True)
+
+
+def test_walking_directory_prefix_suffix():
+    shutil.rmtree('output', ignore_errors=True)
+    prefix = "ivandokov"
+    suffix = "camera"
+    Phockup('input', 'output', output_prefix=prefix, output_suffix=suffix)
+    validate_copy_operations(prefix=prefix, suffix=suffix)
     shutil.rmtree('output', ignore_errors=True)
 
 
@@ -378,41 +403,41 @@ def test_maxdepth_zero():
 def test_maxdepth_one():
     shutil.rmtree('output', ignore_errors=True)
     Phockup('input', 'output', maxdepth=1)
-    validate_copy_operation()
+    validate_copy_operations()
     shutil.rmtree('output', ignore_errors=True)
 
 
 def test_maxconcurrency_none():
     shutil.rmtree('output', ignore_errors=True)
     Phockup('input', 'output', max_concurrency=0)
-    validate_copy_operation()
+    validate_copy_operations()
     shutil.rmtree('output', ignore_errors=True)
 
 
 def test_maxconcurrency_five():
     shutil.rmtree('output', ignore_errors=True)
     Phockup('input', 'output', max_concurrency=5)
-    validate_copy_operation()
+    validate_copy_operations()
     shutil.rmtree('output', ignore_errors=True)
 
 
-def validate_copy_operation():
-    dir1 = 'output/2017/01/01'
-    dir2 = 'output/2017/10/06'
-    dir3 = 'output/unknown'
-    dir4 = 'output/2018/01/01/'
-    assert os.path.isdir(dir1)
-    assert os.path.isdir(dir2)
-    assert os.path.isdir(dir3)
-    assert os.path.isdir(dir4)
-    assert len([name for name in os.listdir(dir1) if
-                os.path.isfile(os.path.join(dir1, name))]) == 3
-    assert len([name for name in os.listdir(dir2) if
-                os.path.isfile(os.path.join(dir2, name))]) == 1
-    assert len([name for name in os.listdir(dir3) if
-                os.path.isfile(os.path.join(dir3, name))]) == 1
-    assert len([name for name in os.listdir(dir4) if
-                os.path.isfile(os.path.join(dir4, name))]) == 1
+def validate_copy_operations(prefix=None, suffix=None):
+    dir1 = '/2017/01/01'
+    dir2 = '/2017/10/06'
+    dir3 = '/unknown'
+    dir4 = '/2018/01/01/'
+    validate_copy_operation(output_root='output', file_path=dir1, expected_count=3, prefix=prefix, suffix=suffix)
+    validate_copy_operation(output_root='output', file_path=dir2, expected_count=1, prefix=prefix, suffix=suffix)
+    validate_copy_operation(output_root='output', file_path=dir3, expected_count=1, prefix=prefix, suffix=suffix)
+    validate_copy_operation(output_root='output', file_path=dir4, expected_count=1, prefix=prefix, suffix=suffix)
+
+
+def validate_copy_operation(output_root, file_path, expected_count, prefix=None, suffix=None):
+    path = [p for p in [output_root, prefix, file_path, suffix] if p is not None]
+    fullpath = os.path.normpath(os.path.sep.join(path))
+    assert os.path.isdir(fullpath)
+    assert len([name for name in os.listdir(fullpath) if
+                os.path.isfile(os.path.join(fullpath, name))]) == expected_count
 
 
 def test_no_exif_directory():


### PR DESCRIPTION
Addresses #146 

Adding support for output directory prefix and suffix support to aid in storing files with an additional layer of taxonomy.  

- Added `--output-prefix` command line argument support
- Added `--output-suffix` command line argument support
- Updated `get_output_dir` to support assembling directory paths with prefix and/or suffix parameters
- Updated 'unknown' folder support to include prefix and suffix directives when storing files with unknown date information.
- Updated `--skip-unknown` to support directories other than "unknown" when specified via the `--no-date-dir` argument
- Implemented test cases for prefix, suffix, and prefix+suffix
- Refactored `validate_copy_operations` to support prefix and suffix tests

See readme for details on use cases for prefix and suffix