### PR TITLE
Make sure arguments are not split

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # If the CRON variable is empty, phockup gets executed once as command line tool
 if [ -z "$CRON" ]; then
-  phockup $@
+  phockup "$@"
 
 # When CRON is not empty, phockup will run in a cron job until the container is stopped.
 else


### PR DESCRIPTION
See also https://www.shellcheck.net/wiki/SC2068, especially setting multiple whitespace separated date-fields is now possible when using the container.