### PR TITLE
add python_date parameter

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -70,6 +70,35 @@ Example:
 """,
     )
 
+    parser.add_argument(
+        '--python_date',
+        action='store',
+        help="""\
+Specify date format in python datetime fomat for OUTPUTDIR directories.
+
+This will take precedence over --date parameter. Any characters not escaped by '%' will bet part of OUTPUTDIR as literal.
+
+Supported formats:
+    %Y   - 2016, 2017 ...
+    %y   - 16, 17 ...
+    %m   - 07, 08, 09 ...
+    %B   - July, August, September ...
+    %b   - Jul, Aug, Sept ...
+    %d   - 27, 28, 29 ... (day of month)
+    %j   - 123, 158, 365 ... (day of year)
+    %U   - 00, 01, 53 ... (week of the year, Sunday first day of week)
+    %W   - 00, 01, 53 ... (week of the year, Monday first day of week)
+
+Example:
+    %Y/%m/%d -> 2011/07/17
+    %Y/Months/%B/%d  -> 2011/Months/July/17
+    %Y/Months/%b/%d  -> 2011/Months/Jul/17
+    %y/Months/%b-%d    -> 11/Months/Jul-17
+    %Y/%U     -> 2011/30
+    %Y/%W     -> 2011/28
+""",
+    )
+
     exclusive_group_link_move = parser.add_mutually_exclusive_group()
 
     exclusive_group_link_move.add_argument(
@@ -329,6 +358,7 @@ def main(options):
         options.input_dir,
         options.output_dir,
         dir_format=options.date,
+        python_dir_format=options.python_date,
         move=options.move,
         link=options.link,
         date_regex=options.regex,

--- a/readme.md
+++ b/readme.md
@@ -128,6 +128,31 @@ Example:
     YYYY/W     -> 2011/28
 ```
 
+Date format can also be passed in Python datetime format using the `--python_date` argument. This argument will take 
+precedence over the `-d | --date` argument. Any characters not escaped by `%` as part of Python datetime format will
+be included as part of OUTPUTDIR as literal text.
+
+```
+Supported formats:
+    %Y   - 2016, 2017 ...
+    %y   - 16, 17 ...
+    %m   - 07, 08, 09 ...
+    %B   - July, August, September ...
+    %b   - Jul, Aug, Sept ...
+    %d   - 27, 28, 29 ... (day of month)
+    %j   - 123, 158, 365 ... (day of year)
+    %U   - 00, 01, 53 ... (week of the year, Sunday first day of week)
+    %W   - 00, 01, 53 ... (week of the year, Monday first day of week)
+
+Example:
+    %Y/%m/%d         -> 2011/07/17
+    %Y/Months/%B/%d  -> 2011/Months/July/17
+    %Y/Months/%b/%d  -> 2011/Months/Jul/17
+    %y/Months/%b-%d  -> 11/Months/Jul-17
+    %Y/%U            -> 2011/30
+    %Y/%W            -> 2011/28
+```
+
 ### Prefix/Suffix
 In order to support both aggregation and finer granularity of files
 sorted, you can specify a prefix or suffix (or both) to aid in storing

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -42,7 +42,7 @@ class Phockup:
         self.output_prefix = args.get('output_prefix' or None)
         self.output_suffix = args.get('output_suffix' or '')
         self.no_date_dir = args.get('no_date_dir') or Phockup.DEFAULT_NO_DATE_DIRECTORY
-        self.dir_format = args.get('dir_format') or os.path.sep.join(Phockup.DEFAULT_DIR_FORMAT)
+        self.dir_format = args.get('python_dir_format') or args.get('dir_format') or os.path.sep.join(Phockup.DEFAULT_DIR_FORMAT)
         self.move = args.get('move', False)
         self.link = args.get('link', False)
         self.original_filenames = args.get('original_filenames', False)


### PR DESCRIPTION
I'm still interested in the original use case as described in #146. I have photos stored in folder structure by Year/Album (ex. 2021/Hawaii) and I would like to autosort any photos that don't fit into an album in Year/Months/Month (ex. 2019/Months/August). It seems Python datetime format already has '%' prefix for all formats, so if we skip the Date.parse on the '--date' argument then we can use Python datetime format directly and any other text will be passed through literally to the OUTPUTDIR. I've added this as a new argument that takes precedence over '--date'. Wondering is this is an acceptable solution. 

added --python_date argument to further address #146. Python datetime format is refixed with '%' so other text is treated as literal.