### PR TITLE
Update documentaion to match folders created in Docker file

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ In this mode, all phockup parameters need to be passed as direct parameters with
 To execute phockup only once, use the following command:
 
 ```
-docker run -v ~/Pictures:/mnt ivandokov/phockup:latest /mnt/Input /mnt/Output [PHOCKUP ARGUMENTS]
+docker run -v ~/Pictures:/mnt ivandokov/phockup:latest /mnt/input /mnt/output [PHOCKUP ARGUMENTS]
 ```
 
 #### Continuous execution mode


### PR DESCRIPTION
#197 

When I ran the one shot docker command for the first time I started with the example in the documentation. While this worked there was some confusion as the Dockerfile will create `/mnt/input` and `/mnt/output` automatically. With this PR this behaviour doesn't change but is less noticeable.