### PR TITLE
Adde from_date and to_date options to limit the processed files

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -296,6 +296,28 @@ folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
         files by an additional level after sorting by date.
         """
     )
+    
+    parser.add_argument(
+        '--from_date',
+        type=str,
+        default=None,
+        help="""\
+Limit the operations to the files that are older than from_date (inclusive).
+The date must be specified in format YYYY-MM-DD
+Files with unknown date won't be skipped.
+"""
+    )
+
+    parser.add_argument(
+        '--to_date',
+        type=str,
+        default=None,
+        help="""\
+Limit the operations to the files that are newer than from_date (inclusive).
+The date must be specified in format YYYY-MM-DD
+Files with unknown date won't be skipped.
+"""
+    )
 
     return parser.parse_args(args)
 
@@ -344,7 +366,9 @@ def main(options):
         no_date_dir=options.no_date_dir,
         skip_unknown=options.skip_unknown,
         output_prefix=options.output_prefix,
-        output_suffix=options.output_suffix
+        output_suffix=options.output_suffix,
+        from_date=options.from_date,
+        to_date=options.to_date
     )
 
 

--- a/phockup.py
+++ b/phockup.py
@@ -298,24 +298,22 @@ folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
     )
     
     parser.add_argument(
-        '--from_date',
+        '--from-date',
         type=str,
         default=None,
         help="""\
-Limit the operations to the files that are older than from_date (inclusive).
-The date must be specified in format YYYY-MM-DD
-Files with unknown date won't be skipped.
+Limit the operations to the files that are newer than --from-date (inclusive).
+The date must be specified in format YYYY-MM-DD. Files with unknown date won't be skipped.
 """
     )
 
     parser.add_argument(
-        '--to_date',
+        '--to-date',
         type=str,
         default=None,
         help="""\
-Limit the operations to the files that are newer than from_date (inclusive).
-The date must be specified in format YYYY-MM-DD
-Files with unknown date won't be skipped.
+Limit the operations to the files that are older than --to-date (inclusive).
+The date must be specified in format YYYY-MM-DD. Files with unknown date won't be skipped.
 """
     )
 

--- a/readme.md
+++ b/readme.md
@@ -220,6 +220,29 @@ saving to the same central respository.
 
 The two options above can be used to help sort/store images
 
+#### Limit files processed by date
+`--from-date` flag can be used to limit the operations to the files that are newer than the provided date (inclusive).
+The date must be specified in format YYYY-MM-DD. Files with unknown date won't be skipped.
+
+For example:
+```
+phockup ~/Pictures/DCIM/NIKOND40 ~/Pictures/sorted --from-date="2017-01-02"
+```
+`--to-date` flag can be used to limit the operations to the files that are older than the provided date (inclusive).
+The date must be specified in format YYYY-MM-DD. Files with unknown date won't be skipped.
+
+For example:
+```
+phockup ~/Pictures/DCIM/NIKOND40 ~/Pictures/sorted --to-date="2017-01-02"
+```  
+
+`--from-date` and `--to-date` can be combined for better control over the files that are processed.
+
+For example:
+```
+phockup ~/Pictures/DCIM/NIKOND40 ~/Pictures/sorted --from-date="2017-01-02" --to-date="2017-01-03"
+``` 
+
 ### Missing date information in EXIF
 If any of the photos does not have date information you can use the `-r | --regex` option to specify date format for date extraction from filenames:
 ```

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -284,10 +284,10 @@ but looking for '{self.file_type}'"
                 if type(file_date) is dict:
                     file_date = file_date["date"]
                 if self.from_date is not None and file_date < self.from_date:
-                    progress = f"{progress} => {filename} skipped: date {file_date} is older than from_date {self.from_date}"
+                    progress = f"{progress} => {filename} skipped: date {file_date} is older than --from-date {self.from_date}"
                     skip = True
                 if self.to_date is not None and file_date > self.to_date:
-                    progress = f"{progress} => {filename} skipped: date {file_date} is newer than to_date {self.to_date}"
+                    progress = f"{progress} => {filename} skipped: date {file_date} is newer than --to-date {self.to_date}"
                     skip = True
                 if skip:
                     if self.progress:

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -281,7 +281,6 @@ but looking for '{self.file_type}'"
 
             if not date_unknown:
                 skip = False
-                print(f"Filedate is {file_date}")
                 if type(file_date) is dict:
                     file_date = file_date["date"]
                 if self.from_date is not None and file_date < self.from_date:

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -473,3 +473,66 @@ def test_skip_unknown():
     assert len([name for name in os.listdir(dir4) if
                 os.path.isfile(os.path.join(dir4, name))]) == 1
     shutil.rmtree('output', ignore_errors=True)
+
+def test_from_date():
+    shutil.rmtree('output', ignore_errors=True)
+    Phockup('input', 'output', from_date="2017-10-06")
+    dir1 = 'output/2017/01/01'
+    dir2 = 'output/2017/10/06'
+    dir3 = 'output/unknown'
+    dir4 = 'output/2018/01/01/'
+    assert os.path.isdir(dir1)
+    assert os.path.isdir(dir2)
+    assert os.path.isdir(dir3)
+    assert os.path.isdir(dir4)
+    assert len([name for name in os.listdir(dir1) if
+                os.path.isfile(os.path.join(dir1, name))]) == 0
+    assert len([name for name in os.listdir(dir2) if
+                os.path.isfile(os.path.join(dir2, name))]) == 1
+    assert len([name for name in os.listdir(dir3) if
+                os.path.isfile(os.path.join(dir3, name))]) == 1
+    assert len([name for name in os.listdir(dir4) if
+                os.path.isfile(os.path.join(dir4, name))]) == 1
+    shutil.rmtree('output', ignore_errors=True)
+
+def test_to_date():
+    shutil.rmtree('output', ignore_errors=True)
+    Phockup('input', 'output', to_date="2017-10-06", progress=True)
+    dir1 = 'output/2017/01/01'
+    dir2 = 'output/2017/10/06'
+    dir3 = 'output/unknown'
+    dir4 = 'output/2018/01/01/'
+    assert os.path.isdir(dir1)
+    assert os.path.isdir(dir2)
+    assert os.path.isdir(dir3)
+    assert os.path.isdir(dir4)
+    assert len([name for name in os.listdir(dir1) if
+                os.path.isfile(os.path.join(dir1, name))]) == 3
+    assert len([name for name in os.listdir(dir2) if
+                os.path.isfile(os.path.join(dir2, name))]) == 1
+    assert len([name for name in os.listdir(dir3) if
+                os.path.isfile(os.path.join(dir3, name))]) == 1
+    assert len([name for name in os.listdir(dir4) if
+                os.path.isfile(os.path.join(dir4, name))]) == 0
+    shutil.rmtree('output', ignore_errors=True)
+
+def test_from_date_to_date():
+    shutil.rmtree('output', ignore_errors=True)
+    Phockup('input', 'output', to_date="2017-10-06", from_date="2017-01-02", progress=True)
+    dir1 = 'output/2017/01/01'
+    dir2 = 'output/2017/10/06'
+    dir3 = 'output/unknown'
+    dir4 = 'output/2018/01/01/'
+    assert os.path.isdir(dir1)
+    assert os.path.isdir(dir2)
+    assert os.path.isdir(dir3)
+    assert os.path.isdir(dir4)
+    assert len([name for name in os.listdir(dir1) if
+                os.path.isfile(os.path.join(dir1, name))]) == 0
+    assert len([name for name in os.listdir(dir2) if
+                os.path.isfile(os.path.join(dir2, name))]) == 1
+    assert len([name for name in os.listdir(dir3) if
+                os.path.isfile(os.path.join(dir3, name))]) == 1
+    assert len([name for name in os.listdir(dir4) if
+                os.path.isfile(os.path.join(dir4, name))]) == 0
+    shutil.rmtree('output', ignore_errors=True)


### PR DESCRIPTION
This PR adds `from_date` and `to_date` command line options to limit the file processing based on the calculated data. Files with unknown date are unfiltered.

This is useful to me because I have a sync folder where the phones keep dumping the data so deleted pictures will be recreated.
I use phockup to copy the pics to a nice structure and then select the ones that I want to keep, so reprocessing all the source folder would replace the photos that I deleted.