### PR TITLE
Feature added: Issue #65

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -288,6 +288,28 @@ folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
     )
 
     parser.add_argument(
+       '--filename_suffix',
+        type=str,
+        default='',
+        help="""\
+        String to append to the output file name. if --filename_add_original is set, this will be added after the original filename.
+        This string can also be setting of the output name (e.g. via $USER,
+        $HOSTNAME, %USERNAME%, etc.)
+        """
+
+    )
+
+
+    parser.add_argument(
+        '-ao',
+        '--filename_add_original',
+        action='store_true',
+        help="""\
+Add original filename to the  target filename
+""",
+    )
+
+    parser.add_argument(
         '--output_suffix',
         type=str,
         default='',
@@ -344,7 +366,9 @@ def main(options):
         no_date_dir=options.no_date_dir,
         skip_unknown=options.skip_unknown,
         output_prefix=options.output_prefix,
-        output_suffix=options.output_suffix
+        output_suffix=options.output_suffix,
+        filename_suffix=options.filename_suffix,
+        filename_add_original=options.filename_add_original
     )
 
 

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -41,6 +41,10 @@ class Phockup:
         self.output_dir = output_dir
         self.output_prefix = args.get('output_prefix' or None)
         self.output_suffix = args.get('output_suffix' or '')
+        
+        self.filename_suffix=args.get('filename_suffix' or '')
+        self.filename_add_original = args.get('filename_add_original', False)
+
         self.no_date_dir = args.get('no_date_dir') or Phockup.DEFAULT_NO_DATE_DIRECTORY
         self.dir_format = args.get('dir_format') or os.path.sep.join(Phockup.DEFAULT_DIR_FORMAT)
         self.move = args.get('move', False)
@@ -203,7 +207,7 @@ class Phockup:
         """
         if self.original_filenames:
             return os.path.basename(original_filename)
-
+        
         try:
             filename = [
                 f'{date["date"].year :04d}',
@@ -217,8 +221,23 @@ class Phockup:
 
             if date['subseconds']:
                 filename.append(date['subseconds'])
+            
+            # target filename with timestamp as name
+            target_filename=''.join(filename)
 
-            return ''.join(filename) + os.path.splitext(original_filename)[1]
+            if self.filename_add_original:
+                base_name=os.path.basename(original_filename)
+                f_name=os.path.splitext(base_name)[0]
+                target_filename=''.join(filename) + '_' + f_name
+                #debug
+                # print(target_filename+os.path.splitext(original_filename)[1])
+                
+            if self.filename_suffix:
+                target_filename=target_filename + '_' + self.filename_suffix
+                # print(target_filename)
+                
+            return target_filename + os.path.splitext(original_filename)[1]
+        
         # TODO: Double check if this is correct!
         except TypeError:
             return os.path.basename(original_filename)
@@ -335,8 +354,9 @@ but looking for '{self.file_type}'"
                                             self.date_field)
             output = self.get_output_dir(date)
             target_file_name = self.get_file_name(filename, date)
-            if not self.original_filenames:
-                target_file_name = target_file_name.lower()
+            
+            # if not self.original_filenames:
+                # target_file_name = target_file_name.lower()
         else:
             output = self.get_output_dir([])
             target_file_name = os.path.basename(filename)


### PR DESCRIPTION
Added feature - Issue #65.

### New flags added 🥳 
**--filename_add_original** (or) **-ao** : Adds the original filename to the new filename
**--filename_suffix** : Adds a custom suffix to the new filename.

### Sample Output:

```
1227c98e03af:/opt/phockup# ./phockup.py /mnt/test_input/ /mnt/test_output/ -y --filename_add_original --filename_suffix=NIKON

[2023-07-01 12:02:01] - [WARNING] - Dry-run phockup (does a trial run with no permanent changes)...
[2023-07-01 12:02:01] - [INFO] - /mnt/test_input/DSCF1904.JPG => /mnt/test_output/2023/05/18/20230518-041043_DSCF1904_NIKON.JPG
[2023-07-01 12:02:01] - [INFO] - Processed 1 files in 0.10 seconds. Average Throughput: 9.93 files/second
[2023-07-01 12:02:01] - [INFO] - Would have copied 1 files.

1227c98e03af:/opt/phockup# ./phockup.py /mnt/test_input/ /mnt/test_output/ -y --filename_add_original 
[2023-07-01 12:11:13] - [WARNING] - Dry-run phockup (does a trial run with no permanent changes)...
[2023-07-01 12:11:13] - [INFO] - /mnt/test_input/DSCF1904.JPG => /mnt/test_output/2023/05/18/20230518-041043_DSCF1904.JPG
[2023-07-01 12:11:13] - [INFO] - Processed 1 files in 0.09 seconds. Average Throughput: 10.63 files/second

1227c98e03af:/opt/phockup# ./phockup.py /mnt/test_input/ /mnt/test_output/ -y --filename_suffix=NIKON
[2023-07-01 12:12:14] - [WARNING] - Dry-run phockup (does a trial run with no permanent changes)...
[2023-07-01 12:12:15] - [INFO] - /mnt/test_input/DSCF1904.JPG => /mnt/test_output/2023/05/18/20230518-041043_NIKON.JPG
[2023-07-01 12:12:15] - [INFO] - Processed 1 files in 0.09 seconds. Average Throughput: 10.55 files/second
[2023-07-01 12:12:15] - [INFO] - Would have copied 1 files.

1227c98e03af:/opt/phockup# ./phockup.py /mnt/test_input/ /mnt/test_output/ -y
[2023-07-01 12:12:40] - [WARNING] - Dry-run phockup (does a trial run with no permanent changes)...
[2023-07-01 12:12:40] - [INFO] - /mnt/test_input/DSCF1904.JPG => /mnt/test_output/2023/05/18/20230518-041043.JPG
[2023-07-01 12:12:40] - [INFO] - Processed 1 files in 0.09 seconds. Average Throughput: 10.66 files/second
[2023-07-01 12:12:40] - [INFO] - Would have copied 1 files.

``` 