### PR TITLE
Fix --help printing

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -283,7 +283,7 @@ folder name. e.g. --no-date-dir=misc, --no-date-dir="no date"
         files by an additional level prior to sorting by date.  This
         string will immediately follow the output path and is intended
         to allow runtime setting of the output path (e.g. via $USER,
-        $HOSTNAME, %USERNAME%, etc.)
+        $HOSTNAME, %%USERNAME%%, etc.)
         """
     )
 


### PR DESCRIPTION
Currently `--help` is busted because python is interpreting %U as a format character. Fix it.

Before:
```
~> docker run phockup --help
unsupported format character 'U' (0x55) at index 297
```

After:
```
~> docker run phockup --help
usage: phockup [-h] [-v] [-d DATE] [-m | -l] [-o] [-t] [-y] [-c 1-255]
               [--maxdepth 1-255] [-r REGEX] [-f DATE_FIELD]
               [--debug | --quiet | --progress] [--log LOG]
               [--file-type image|video] [--no-date-dir NO_DATE_DIR]
               [--skip-unknown] [--output_prefix OUTPUT_PREFIX]
               [--output_suffix OUTPUT_SUFFIX]
               INPUTDIR OUTPUTDIR

Media sorting tool to organize photos and videos from your camera in folders by year, month and day.
The software will collect all files from the input directory and copy them to the output
directory without changing the files content. It will only rename the files and  place
them in the proper directory for year, month and day.
...
```