### PR TITLE
1. ignoring @eaDir directories 2. setting UID and GID of copy / move process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,14 @@ ENV CRON ""
 ENV OPTIONS ""
 
 COPY . /opt/phockup
-RUN chmod +x /opt/phockup/entrypoint.sh
 
 RUN apk --no-cache add exiftool \
     && pip install --no-cache-dir -r /opt/phockup/requirements.txt \
     && ln -s /opt/phockup/phockup.py /usr/local/bin/phockup \
     && apk add bash \
-    && apk add flock
+    && apk add flock \
+	&& apk add util-linux-login
+
+RUN ["chmod", "-R", "a+rx", "/opt/phockup/"]
 
 ENTRYPOINT ["/opt/phockup/entrypoint.sh"]


### PR DESCRIPTION
I use a synology NAS and the @eaDir directories were causing problems, so the updates to phockup.py ignore the directories, and form the base of being able to ignore more directories in the future.
I also wanted the move to use the right permissions, so entrypoint.sh does an su to the user, and there's two new env variables: PHOCKUP_UID and PHOCKUP_GID