### PR TITLE
implement movedel

### DIFF
--- a/phockup.py
+++ b/phockup.py
@@ -276,6 +276,16 @@ Example:
             """,
     )
 
+    exclusive_group_debug_silent.add_argument(
+        '--movedel',
+        action='store_true',
+        default=False,
+        help="""\
+            DELETE source files which are determined to be duplicates of files
+            already transferred.  Only valid in conjunction with both `--move`
+            and `--skip-unknown`.
+            """,
+    )
     parser.add_argument(
         '--output_prefix',
         type=str,
@@ -365,6 +375,7 @@ def main(options):
         max_concurrency=options.max_concurrency,
         no_date_dir=options.no_date_dir,
         skip_unknown=options.skip_unknown,
+        movedel=options.movedel,
         output_prefix=options.output_prefix,
         output_suffix=options.output_suffix,
         from_date=options.from_date,

--- a/phockup.py
+++ b/phockup.py
@@ -276,7 +276,7 @@ Example:
             """,
     )
 
-    exclusive_group_debug_silent.add_argument(
+    parser.add_argument(
         '--movedel',
         action='store_true',
         default=False,

--- a/src/phockup.py
+++ b/src/phockup.py
@@ -50,6 +50,7 @@ class Phockup:
         self.timestamp = args.get('timestamp', False)
         self.date_field = args.get('date_field', False)
         self.skip_unknown = args.get("skip_unknown", False)
+        self.movedel = args.get("movedel", False),
         self.dry_run = args.get('dry_run', False)
         self.progress = args.get('progress', False)
         self.max_depth = args.get('max_depth', -1)
@@ -297,7 +298,12 @@ but looking for '{self.file_type}'"
 
             if os.path.isfile(target_file):
                 if filename != target_file and filecmp.cmp(filename, target_file, shallow=False):
-                    progress = f'{progress} => skipped, duplicated file {target_file}'
+                    if self.movedel and self.move and self.skip_unknown:
+                        if not self.dry_run:
+                            os.remove(filename)
+                        progress = f'{progress} => deleted, duplicated file {target_file}'
+                    else:
+                        progress = f'{progress} => skipped, duplicated file {target_file}'
                     self.duplicates_found += 1
                     if self.progress:
                         self.pbar.write(progress)

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -290,6 +290,27 @@ def test_process_move(mocker):
     shutil.rmtree('output', ignore_errors=True)
 
 
+def test_process_movedel(mocker, caplog):
+    shutil.rmtree('output', ignore_errors=True)
+    mocker.patch.object(Phockup, 'check_directories')
+    mocker.patch.object(Phockup, 'walk_directory')
+    mocker.patch.object(Exif, 'data')
+    Exif.data.return_value = {
+        "MIMEType": "image/jpeg"
+    }
+    phockup = Phockup('input', 'output', move=True, movedel=True, skip_unknown=True)
+    open("input/tmp_20170101_010101.jpg", "w").close()
+    open("input/sub_folder/tmp_20170101_010101.jpg", "w").close()
+    phockup.process_file("input/tmp_20170101_010101.jpg")
+    assert not os.path.isfile("input/tmp_20170101_010101.jpg")
+    assert os.path.isfile("output/2017/01/01/20170101-010101.jpg")
+    with caplog.at_level(logging.INFO):
+        phockup.process_file("input/sub_folder/tmp_20170101_010101.jpg")
+    assert 'deleted, duplicated file' in caplog.text
+    assert not os.path.isfile("input/sub_folder/tmp_20170101_010101.jpg")
+    shutil.rmtree('output', ignore_errors=True)
+
+
 def test_process_link(mocker):
     shutil.rmtree('output', ignore_errors=True)
     mocker.patch.object(Phockup, 'check_directories')


### PR DESCRIPTION
Implement `move or delete` option: if both `move` and `skip_unknown` are enabled, adding this flag will cause the source file to be deleted.  This addition enables merging multiple redundant libraries into one.
