### PR TITLE
fix movedel and rmdirs trailing commas, made always true

### DIFF
--- a/src/phockup.py
+++ b/src/phockup.py
@@ -49,17 +49,17 @@ class Phockup:
         self.date_regex = args.get('date_regex', None)
         self.timestamp = args.get('timestamp', False)
         self.date_field = args.get('date_field', False)
-        self.skip_unknown = args.get("skip_unknown", False)
-        self.movedel = args.get("movedel", False),
-        self.rmdirs = args.get("rmdirs", False),
+        self.skip_unknown = args.get('skip_unknown', False)
+        self.movedel = args.get('movedel', False)
+        self.rmdirs = args.get('rmdirs', False)
         self.dry_run = args.get('dry_run', False)
         self.progress = args.get('progress', False)
         self.max_depth = args.get('max_depth', -1)
         # default to concurrency of one to retain existing behavior
-        self.max_concurrency = args.get("max_concurrency", 1)
+        self.max_concurrency = args.get('max_concurrency', 1)
 
-        self.from_date = args.get("from_date", None)
-        self.to_date = args.get("to_date", None)
+        self.from_date = args.get('from_date', None)
+        self.to_date = args.get('to_date', None)
         if self.from_date is not None:
             self.from_date = Date.strptime(f"{self.from_date} 00:00:00", "%Y-%m-%d %H:%M:%S")
         if self.to_date is not None:

--- a/tests/test_phockup.py
+++ b/tests/test_phockup.py
@@ -278,6 +278,7 @@ def test_process_move(mocker):
     Exif.data.return_value = {
         "MIMEType": "image/jpeg"
     }
+    os.mkdir('input/sub0')
     phockup = Phockup('input', 'output', move=True)
     open("input/tmp_20170101_010101.jpg", "w").close()
     open("input/tmp_20170101_010101.xmp", "w").close()
@@ -287,7 +288,9 @@ def test_process_move(mocker):
     assert not os.path.isfile("input/tmp_20170101_010101.xmp")
     assert os.path.isfile("output/2017/01/01/20170101-010101.jpg")
     assert os.path.isfile("output/2017/01/01/20170101-010101.xmp")
+    assert os.path.isdir("input/sub0")  # empty dir not deleted
     shutil.rmtree('output', ignore_errors=True)
+    os.rmdir('input/sub0')
 
 
 def test_process_movedel(mocker, caplog):


### PR DESCRIPTION
Closes #230, with test.

As noted in comments to https://github.com/ivandokov/phockup/pull/225, --move results in empty subdirectories being removed. This is due to an erroneous traling comma in the variable initializaition for rmdirs, so it always reads as enabled.